### PR TITLE
Update/area reps 9 2019

### DIFF
--- a/src/components/resources/resources-constants.js
+++ b/src/components/resources/resources-constants.js
@@ -194,4 +194,12 @@ export const pastPresidents = [
     year: '2016-2017',
     name: 'Dean Muths',
   },
+  {
+    year: '2017-2018',
+    name: 'JD Janda',
+  },
+  {
+    year: '2018-2019',
+    name: 'Patricia Moreno',
+  },
 ];

--- a/src/components/resources/resources-constants.js
+++ b/src/components/resources/resources-constants.js
@@ -79,6 +79,10 @@ export const outstandingAdmin = [
     year: '2018',
     name: 'Monte Mast',
   },
+  {
+    year: '2019',
+    name: 'James Drew',
+  },
 ];
 
 export const pastPresidents = [

--- a/src/components/shared/sponsor-card/index.js
+++ b/src/components/shared/sponsor-card/index.js
@@ -1,53 +1,99 @@
 // External Dependencies
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Link } from 'gatsby';
-import { css } from 'glamor';
+import { makeStyles } from '@material-ui/styles';
 
 // Local Variables
-const sponsorInfoStyles = {
-  alignItems: 'center',
-  display: 'flex',
-  flexDirection: 'column',
+const propTypes = {
+  max: PropTypes.number,
+  min: PropTypes.number,
+  sponsorClass: PropTypes.string.isRequired,
+  sponsorData: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-// Let's add some animation to the titles of the sponsor levels!
-const textShadowDropBottom = css.keyframes({
-  '0%': { textShadow: '0 0 0 rgba(0, 0, 0, 0)' },
-  '100%': { textShadow: '0 3px 3px rgba(0, 0, 0, 0.2)' },
+const defaultProps = {
+  max: null,
+  min: null,
+  sponsorData: [],
+};
+
+const useStyles = makeStyles({
+  deadlineText: {
+    marginBottom: 16,
+    maxWidth: '75%',
+  },
+  deadlineTextBottom: {
+    maxWidth: '75%',
+  },
+  divider: {
+    height: 3,
+    marginTop: 32,
+  },
+  list: {
+    maxWidth: '60%',
+    textAlign: 'justify',
+  },
+  payLink: {
+    fontSize: 20,
+    fontWeight: '600',
+    margin: '24px 0',
+  },
+  root: {
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderRadius: 4,
+    boxShadow: 'rgba(25, 17, 34, 0.05) 0px 3px 10px',
+    marginBottom: '1em',
+    padding: '2em 3em',
+  },
+  sponsorInfo: {
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  sponsorLink: {
+    margin: '0 8px',
+  },
+  sponsorLinktText: {
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    fontSize: '1.25rem',
+    height: 48,
+    justifyContent: 'center',
+    marginBottom: 6,
+  },
+  strongText: {
+    fontWeight: 600,
+  },
+  titleFour: {
+    color: TITLE_BLUE,
+    marginTop: '1.25rem',
+  },
 });
 
+const TITLE_BLUE = '#32456B';
+
 // Component Definition
-class SponsorCard extends Component {
-  static propTypes = {
-    max: PropTypes.number,
-    min: PropTypes.number,
-    sponsorClass: PropTypes.string.isRequired,
-    sponsorData: PropTypes.arrayOf(PropTypes.shape({})),
-  };
+const SponsorCard = (props) => {
+  const {
+    max,
+    min,
+    sponsorClass,
+    sponsorData,
+  } = props;
 
-  static defaultProps = {
-    max: null,
-    min: null,
-    sponsorData: [],
-  };
+  const classes = useStyles(props);
 
-  renderSponsors = sponsorData =>
+  const renderSponsors = sponsorData =>
     sponsorData.length > 0 && sponsorData.map(sponsor => (
       <div
+        className={classes.sponsorLinktText}
         key={sponsor.SponsorOrganization}
-        css={{
-          alignItems: 'center',
-          display: 'flex',
-          flexDirection: 'column',
-          fontSize: '1.25rem',
-          height: 48,
-          justifyContent: 'center',
-          marginBottom: 6,
-        }}
       >
         <a
-          css={{ marginBottom: 16 }}
+          className={classes.sponsorLink}
           href={sponsor.OrganizationWebsiteAddress.startsWith('http') ? sponsor.OrganizationWebsiteAddress : `http://${sponsor.OrganizationWebsiteAddress}`}
           target="_blank"
           rel="noopener noreferrer"
@@ -57,81 +103,53 @@ class SponsorCard extends Component {
       </div>
     ));
 
-  render() {
-    const {
-      max,
-      min,
-      sponsorClass,
-      sponsorData,
-    } = this.props;
+  const donationAmount = min
+    ? `${min.toLocaleString()}-${max.toLocaleString()}`
+    : `${max.toLocaleString()}+`;
 
-    const donationAmount = min
-      ? `${min.toLocaleString()}-${max.toLocaleString()}`
-      : `${max.toLocaleString()}+`;
+  return (
+    <div className={classes.root}>
+      <h2>
+        {sponsorClass}
+      </h2>
+      <h4 className={classes.titleFour}>
+        (${donationAmount} donation)
+      </h4>
 
-    return (
-      <div
-        css={{
-          alignItems: 'center',
-          backgroundColor: 'white',
-          borderRadius: 4,
-          boxShadow: 'rgba(25, 17, 34, 0.05) 0px 3px 10px',
-          marginBottom: '1em',
-          padding: '2em 3em',
-        }}
-      >
-        <h2
-          css={css({
-            animation: `${textShadowDropBottom} 2s both`,
-          })}
-        >
-          {sponsorClass}
-        </h2>
-        <h4
-          css={{
-            color: '#32456B',
-            marginTop: '1.25rem',
-          }}
-        >
-          (${donationAmount} donation)
-        </h4>
+      {sponsorData.length > 0 && <hr className={classes.divider} />}
 
-        {sponsorData.length > 0 && <hr css={{ color: 'blue', height: 3, marginTop: 32 }} />}
+      {renderSponsors(sponsorData)}
 
-        {this.renderSponsors(sponsorData)}
+      <hr className={classes.divider} />
 
-        <hr css={{ color: 'blue', height: 3, marginTop: 32 }} />
-
-        <div css={sponsorInfoStyles}>
-          <h4 css={{ color: '#32456B', marginTop: 12 }}>Sponsorship receives:</h4>
-          <ul css={{ maxWidth: '60%', textAlign: 'justify' }}>
-            {sponsorClass === 'Class Champion' && <li>Up to 20 min presentation to TMAC membership at either November Conference or TMEA Meeting</li>}
-            <li>Company Logo in programs for TMAC November Conference and TMEA Meeting</li>
-            <li>Company Logo on TMAC website</li>
-          </ul>
-          <div css={{ maxWidth: '75%', marginBottom: 16 }}>
-            Deadline for recogntion at{' '}
-            <span css={{ fontWeight: 600 }}>Fall Conference</span> is Wednesday, November 6th.
-          </div>
-          <div css={{ maxWidth: '75%' }}>{' '}
-            Sponsors registering after November 6th will be recogized at the{' '}
-            <span css={{ fontWeight: 600 }}>TMEA Round Table</span>.
-          </div>
-          <Link
-            css={{
-              fontSize: 20,
-              fontWeight: '600',
-              margin: '24px 0',
-            }}
-            to="/sponsors/sponsor-info"
-            state={{ level: sponsorClass }}
-          >
-            Click here to register and pay
-          </Link>
+      <div className={classes.sponsorInfo}>
+        <h4 className={classes.titleFour}>Sponsorship receives:</h4>
+        <ul className={classes.list}>
+          {sponsorClass === 'Class Champion' && <li>Up to 20 min presentation to TMAC membership at either November Conference or TMEA Meeting</li>}
+          <li>Company name in programs for TMAC November Conference and TMEA Meeting</li>
+          <li>Company name on TMAC website</li>
+        </ul>
+        <div className={classes.deadlineText}>
+          Deadline for recogntion at{' '}
+          <span className={classes.strongText}>Fall Conference</span> is Wednesday, November 6th.
         </div>
+        <div className={classes.deadlineTextBottom}>{' '}
+          Sponsors registering after November 6th will be recogized at the{' '}
+          <span className={classes.strongText}>TMEA Round Table</span>.
+        </div>
+        <Link
+          className={classes.payLink}
+          state={{ level: sponsorClass }}
+          to="/sponsors/sponsor-info"
+        >
+          Click here to register and pay
+        </Link>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+SponsorCard.propTypes = propTypes;
+SponsorCard.defaultProps = defaultProps;
 
 export default SponsorCard;

--- a/src/components/shared/sponsor-card/index.js
+++ b/src/components/shared/sponsor-card/index.js
@@ -1,4 +1,5 @@
 // External Dependencies
+import Card from '@material-ui/core/Card';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'gatsby';
@@ -19,6 +20,13 @@ const defaultProps = {
 };
 
 const useStyles = makeStyles({
+  card: {
+    background: 'aliceblue',
+    fontSize: '0.9rem',
+    marginBottom: '1rem',
+    maxWidth: '90%',
+    padding: '0 1rem',
+  },
   deadlineText: {
     marginBottom: 16,
     maxWidth: '75%',
@@ -31,7 +39,7 @@ const useStyles = makeStyles({
     marginTop: 32,
   },
   list: {
-    maxWidth: '60%',
+    // maxWidth: '60%',
     textAlign: 'justify',
   },
   payLink: {
@@ -123,18 +131,20 @@ const SponsorCard = (props) => {
       <hr className={classes.divider} />
 
       <div className={classes.sponsorInfo}>
-        <h4 className={classes.titleFour}>Sponsorship receives:</h4>
-        <ul className={classes.list}>
-          {sponsorClass === 'Class Champion' && <li>Up to 20 min presentation to TMAC membership at either November Conference or TMEA Meeting</li>}
-          <li>Company name in programs for TMAC November Conference and TMEA Meeting</li>
-          <li>Company name on TMAC website</li>
-        </ul>
+        <Card className={classes.card} elevation={2}>
+          <h5 className={classes.titleFour}>Sponsorship receives:</h5>
+          <ul className={classes.list}>
+            {sponsorClass === 'Class Champion' && <li>Up to 20 min presentation to TMAC membership at either November Conference or TMEA Meeting</li>}
+            <li>Company name in programs for TMAC November Conference and TMEA Meeting</li>
+            <li>Company name on TMAC website</li>
+          </ul>
+        </Card>
         <div className={classes.deadlineText}>
           Deadline for recogntion at{' '}
           <span className={classes.strongText}>Fall Conference</span> is Wednesday, November 6th.
         </div>
         <div className={classes.deadlineTextBottom}>{' '}
-          Sponsors registering after November 6th will be recogized at the{' '}
+          Sponsors registering after November 6th will be recognized at the{' '}
           <span className={classes.strongText}>TMEA Round Table</span>.
         </div>
         <Link

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,7 +54,7 @@ const useStyles = makeStyles({
 // Component Definition
 const Home = (props) => {
   const {
-    data,
+    // data,
     location,
   } = props;
   const classes = useStyles(props);
@@ -82,7 +82,7 @@ const Home = (props) => {
               If you are a music/fine arts administrator, an aspiring
               administrator, or if you are responsible for the organizing or
               supervision of music activities in your district, we encourage you
-              to become a member of TMAC. We meet as a group three times per year and everyone is invited to attend.  We just ask that you first register to be a member of TMAC.  We meet in July in San Antonio during the summer TBA/TODA/TCDA conference, in November in Austin, and in February as part of the TMEA All-State Music Conference. If you would like more information regarding any of these events, please <Link to="/events/fall-retreat/">visit the event page</Link>.
+              to become a member of TMAC. We meet as a group three times per year and everyone is invited to attend.  We just ask that you first register to be a member of TMAC.  We meet in July in San Antonio during the summer TBA/TODA/TCDA conference, in November in Austin, and in February as part of the TMEA All-State Music Conference. If you would like more information regarding any of these events, please <Link to="/events/fall-retreat/">visit the events page</Link>.
             </FuturaParagraph>
           </Card>
         </Cards>

--- a/src/pages/resources/area-reps.js
+++ b/src/pages/resources/area-reps.js
@@ -25,7 +25,7 @@ const AreaReps = ({ location }) => {
   const north = edges.find(o => o.node.title === 'North Texas').node;
   const central = edges.find(o => o.node.title === 'Central Texas').node;
   const south = edges.find(o => o.node.title === 'South Texas').node;
-  const houston = edges.find(o => o.node.title === 'Greater Houston').node;
+  const southeast = edges.find(o => o.node.title === 'Southeast Texas').node;
   const west = edges.find(o => o.node.title === 'West Texas').node;
 
   return (
@@ -93,17 +93,17 @@ const AreaReps = ({ location }) => {
 
             <Card>
               <Avatar
-                alt="Greater Houston area representative"
-                src={houston.linkToPicture}
+                alt="Southeast Texas area representative"
+                src={southeast.linkToPicture}
               />
-              <CardHeadline>Greater Houston</CardHeadline>
+              <CardHeadline>Southeast Texas</CardHeadline>
               <FuturaParagraph>
-                <a href={`mailto:${houston.email}`}>
-                  {houston.name}
+                <a href={`mailto:${southeast.email}`}>
+                  {southeast.name}
                 </a>
               </FuturaParagraph>
               <FuturaParagraph>
-                {houston.schoolDistrict}
+                {southeast.schoolDistrict}
               </FuturaParagraph>
             </Card>
 

--- a/src/pages/resources/people/james-drew.js
+++ b/src/pages/resources/people/james-drew.js
@@ -1,0 +1,86 @@
+// External Dependencies
+import Helmet from 'react-helmet';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// Internal Dependencies
+import CardHeadline from '../../../components/shared/cards/card-headline';
+import Container from '../../../components/shared/container';
+import FuturaParagraph from '../../../components/shared/futura-paragraph';
+
+// Sidebar data
+import Layout from '../../../components/layout';
+import presets from '../../../utils/presets';
+import resourcesSidebar from '../resources-links.yml';
+import SidebarBody from '../../../components/shared/sidebar/sidebar-body';
+
+// Local Variables
+const rootStyles = {
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  justifyContent: 'space-between',
+};
+
+const imageStyles = {
+  marginBottom: 0,
+};
+
+const headingNameStyles = {
+  marginBottom: 32,
+};
+
+// Component Definition
+const JamesDrew = ({ location }) => (
+  <Layout location={location}>
+    <Helmet>
+      <title>TMAC | James Drew</title>
+    </Helmet>
+    <div css={rootStyles}>
+      <Container>
+        <img
+          alt="James Drew"
+          css={imageStyles}
+          src="https://res.cloudinary.com/tmac/image/upload/v1567444074/james-drew.jpg"
+        />
+        <h2 css={headingNameStyles}>James Drew</h2>
+        <CardHeadline>2019 TMAC Outstanding Administrator</CardHeadline>
+        <FuturaParagraph>
+          Since 2011, James Drew has served as the Director of Fine Arts for the Fort Bend Independent School District in Sugar Land, Texas. Prior to this appointment as Fine Arts Director, James conducted bands and orchestras in the Texas public schools for 21 years, one year in Killeen, Texas and the remaining 20 years in Fort Bend ISD. Ensembles under James’s direction have been selected as state Honor Band finalists and performed at the prestigious Midwest Clinic on four separate occasions. James was chosen the Outstanding Young Bandmaster of the Year in 1997 by the honorary band director’s fraternity, Phi Beta Mu.
+        </FuturaParagraph>
+        <FuturaParagraph>
+          Since his appointment as Fine Arts Director, James has worked tirelessly to advance the Department’s vision of becoming the premier school districts for Fine Arts education in the nation. With the Department’s support, FBISD performing groups and individual students continue to garner state and national recognition. Under James’s leadership, FBISD has added 134 teaching positions, three administrative positions, and two clerical positions to support Arts education. The Department’s annual budget has increased from $1.5 million to $3.1 million and the District has purchased over $5 million in new instruments to replace aging inventory. To develop teaching capacity among FBISD’s Fine Arts staff, James established a job-embedded professional growth model, linking classroom observations with professional coaching. He worked collaboratively with stakeholders to create an innovative program evaluation system to promote excellence in all artistic disciplines. James has implemented new curricula for the District’s 80-plus Fine Arts courses, established a progressive arts-integration teacher network, and initiated an El-Sistema-type, after-school string program. James recently was named the 2019 Music Administrator of the Year by the Texas Music Administrators Conference.
+        </FuturaParagraph>
+        <FuturaParagraph>
+          James earned a Bachelor of Music Education degree from Oral Roberts University, a Master of Music degree in Instrumental Conducting from West Texas State University, and a Master of Arts in Psychology degree from Houston Baptist University. James holds membership in the Texas Music Educators Association, Texas Bandmasters Association, Texas Music Administrators Conference, Alpha Chapter of Phi Beta Mu, and currently serves as the Concert Band Vice-President for the Texas Music Adjudicators Association.
+        </FuturaParagraph>
+        {/* Mobile sidebar */}
+        <div
+          css={{
+            display: `block`,
+            [presets.Tablet]: {
+              display: `none`,
+            },
+          }}>
+          <hr
+            css={{
+              border: 0,
+              height: 2,
+              marginTop: 10,
+            }}
+          />
+          <SidebarBody inline yaml={resourcesSidebar} />
+        </div>
+      </Container>
+    </div>
+  </Layout>
+);
+
+JamesDrew.propTypes = {
+  location: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]).isRequired,
+};
+
+export default JamesDrew;

--- a/src/pages/resources/people/jd-janda.js
+++ b/src/pages/resources/people/jd-janda.js
@@ -1,0 +1,86 @@
+// External Dependencies
+import Helmet from 'react-helmet';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// Internal Dependencies
+import CardHeadline from '../../../components/shared/cards/card-headline';
+import Container from '../../../components/shared/container';
+import FuturaParagraph from '../../../components/shared/futura-paragraph';
+
+// Sidebar data
+import Layout from '../../../components/layout';
+import presets from '../../../utils/presets';
+import resourcesSidebar from '../resources-links.yml';
+import SidebarBody from '../../../components/shared/sidebar/sidebar-body';
+
+// Local Variables
+const rootStyles = {
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  justifyContent: 'space-between',
+};
+
+const imageStyles = {
+  marginBottom: 0,
+};
+
+const headingNameStyles = {
+  marginBottom: 32,
+};
+
+// Component Definition
+const JdJanda = ({ location }) => (
+  <Layout location={location}>
+    <Helmet>
+      <title>TMAC | JD Janda</title>
+    </Helmet>
+    <div css={rootStyles}>
+      <Container>
+        <img
+          alt="JD Janda"
+          css={imageStyles}
+          src="https://res.cloudinary.com/tmac/image/upload/v1523131020/Janda.jpg"
+        />
+        <h2 css={headingNameStyles}>JD Janda</h2>
+        <CardHeadline>TMAC Past President, 2017-2018</CardHeadline>
+        <FuturaParagraph>
+          JD (John David) Janda is the Director of Fine Arts in Tomball ISD, a position he has held since July 2015. In Tomball, Janda supervises the dance, theater, visual arts and music departments of the fast growth district. Immediately prior to moving to Tomball, Janda served six years as the Director of Curriculum and Fine Arts in Georgetown ISD. While in Georgetown, he founded the Vivace Youth Orchestra and served as music director and conductor of VYO’s advanced high school orchestra. JD’s professional career has spanned 38 years - 22 of which were spent in Katy ISD at James E. Taylor High School as Director of Bands and Associate Orchestra Director.
+        </FuturaParagraph>
+        <FuturaParagraph>
+          Janda was recognized for his outstanding contributions to students lives in 2001 when he was named recipient of the “Southwestern Bell - UIL Sponsor Excellence Award” for the State of Texas. His bands earned multiple performances at the UIL State Marching Band Contest and placed high in the TMEA Honor Band process. His bands and orchestras earned many consecutive years of UIL Sweepstakes Awards and won dozens of “Best in Class” awards. Mr. Janda has worked in numerous state-wide leadership capacities.  He recently served on the select committee to rewrite the Texas Essential Knowledge and Skills (TEKS) for Fine Arts. Janda has presented lectures and professional development sessions across Texas - at educator conferences, universities and school districts small and large. He is a Past President of the Texas Music Administrators Conference (TMAC), is a Past President of the Texas Music Educators Association, past TMEA State Band Chair and has served multiple three-year terms as a member of the UIL State Music Technical Advisory Committee.
+        </FuturaParagraph>
+        <FuturaParagraph>
+          JD’s wife of 31 years, Nancy Janda, teaches Algebra at Willow Wood Junior High in Tomball ISD. His daughter, Jane Janda Maloy teaches middle school band in Alvin ISD and Janda’s son Gordon is an assistant band director at Dickinson High School. JD has two awesome, beautiful and amazing grandsons, Elwood James Maloy and Finn Hobbs Maloy.
+        </FuturaParagraph>
+        {/* Mobile sidebar */}
+        <div
+          css={{
+            display: `block`,
+            [presets.Tablet]: {
+              display: `none`,
+            },
+          }}>
+          <hr
+            css={{
+              border: 0,
+              height: 2,
+              marginTop: 10,
+            }}
+          />
+          <SidebarBody inline yaml={resourcesSidebar} />
+        </div>
+      </Container>
+    </div>
+  </Layout>
+);
+
+JdJanda.propTypes = {
+  location: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]).isRequired,
+};
+
+export default JdJanda;

--- a/src/pages/resources/people/patricia-moreno.js
+++ b/src/pages/resources/people/patricia-moreno.js
@@ -1,0 +1,80 @@
+// External Dependencies
+import Helmet from 'react-helmet';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// Internal Dependencies
+import CardHeadline from '../../../components/shared/cards/card-headline';
+import Container from '../../../components/shared/container';
+import FuturaParagraph from '../../../components/shared/futura-paragraph';
+
+// Sidebar data
+import Layout from '../../../components/layout';
+import presets from '../../../utils/presets';
+import resourcesSidebar from '../resources-links.yml';
+import SidebarBody from '../../../components/shared/sidebar/sidebar-body';
+
+// Local Variables
+const rootStyles = {
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  justifyContent: 'space-between',
+};
+
+const imageStyles = {
+  marginBottom: 0,
+};
+
+const headingNameStyles = {
+  marginBottom: 32,
+};
+
+// Component Definition
+const PatriciaMoreno = ({ location }) => (
+  <Layout location={location}>
+    <Helmet>
+      <title>TMAC | Patricia Moreno</title>
+    </Helmet>
+    <div css={rootStyles}>
+      <Container>
+        <img
+          alt="Patricia Moreno"
+          css={imageStyles}
+          src="https://res.cloudinary.com/tmac/image/upload/v1523131020/Moreno.jpg"
+        />
+        <h2 css={headingNameStyles}>Patricia Moreno</h2>
+        <CardHeadline>TMAC Past President, 2018-2019</CardHeadline>
+        <FuturaParagraph>
+          Patricia Moreno, M.M., currently serves as the AISD Instructional Coordinator of General Music and Choral Music, leading one hundred thirty music educators that instruct approximately forty thousand students in music and choral music classes. She taught general and choral music for seventeen years in Hays Consolidated ISD in Title I schools. She is the co-founder and Director of the Kodály Certification Program at Texas State University. She was also appointed by the State Board of Education to serve on the revised Texas Essential Knowledge and Skills (TEKS) committee; co-author of an article, “Fine Arts TEKS Revisions Complete” in TMEA’s Southwestern Musician, reviewer for Oxford University Press and presents workshops across the state.
+        </FuturaParagraph>
+        {/* Mobile sidebar */}
+        <div
+          css={{
+            display: `block`,
+            [presets.Tablet]: {
+              display: `none`,
+            },
+          }}>
+          <hr
+            css={{
+              border: 0,
+              height: 2,
+              marginTop: 10,
+            }}
+          />
+          <SidebarBody inline yaml={resourcesSidebar} />
+        </div>
+      </Container>
+    </div>
+  </Layout>
+);
+
+PatriciaMoreno.propTypes = {
+  location: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]).isRequired,
+};
+
+export default PatriciaMoreno;

--- a/src/pages/resources/resources-links.yml
+++ b/src/pages/resources/resources-links.yml
@@ -14,6 +14,8 @@
       link: /resources/people/bob-bryant/
     - title: David Cain
       link: /resources/people/david-cain/
+    - title: James Drew
+      link: /resources/people/james-drew/
     - title: George W. Jones
       link: /resources/people/george-w.-jones/
     - title: Mitzi Jones
@@ -66,6 +68,8 @@
       link: /resources/people/sam-harris/
     - title: Ken Howard
       link: /resources/people/ken-howard/
+    - title: JD Janda
+      link: /resources/people/jd-janda/
     - title: George W. Jones
       link: /resources/people/george-w.-jones/
     - title: Mitzi Jones

--- a/src/pages/resources/resources-links.yml
+++ b/src/pages/resources/resources-links.yml
@@ -84,6 +84,8 @@
       link: /resources/people/jim-mcdaniel/
     - title: Paul Mann
       link: /resources/people/paul-mann/
+    - title: Patricia Moreno
+      link: /resources/people/patricia-moreno/
     - title: Dean Muths
       link: /resources/people/dean-muths
     - title: Cody Myers


### PR DESCRIPTION
Adds final updates from Jeff Turner's 8/23/2019 email:

- Area rep information
  - Updated on Contentful, but Houston changed to Southeast Texas, so I had to update the content models expected on the front end.
- Past presidents added
  - JD Janda
  - Patty Moreno
- Outstanding Admin added
  - James Drew

Also updated the `SponsorCard` to use the `makeStyles` hook for jss as opposed to glamor of old.