### PR TITLE
fix: isTodayAfterMarch31st was off by one :/

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -36,8 +36,9 @@ export const currentYearLong = format(new Date(), ['YYYY']);
 // Current Year - two-digit string
 export const currentYearShort = format(new Date(), ['YY']);
 
-// Is the current date after July 1st of the current year?
-const isTodayAfterMarch31st = isAfter(new Date(), new Date(currentYearLong, 2, 31));
+// The "year" for TMAC starts on 4/1
+// new Date(2021, 3, 1) → 4/1/2021
+const isTodayAfterMarch31st = isAfter(new Date(), new Date(currentYearLong, 3, 1));
 
 export const currentSchoolYearShort = isTodayAfterMarch31st
   ? `${currentYearShort}-${Number(currentYearShort) + 1}`


### PR DESCRIPTION
# The issue

The `isTodayAfterMarch31st` was off by one day. 😬 

# Right now in prod

It's 3/31, so we should still see "last year's" data

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/11624407/113217193-2bc92a00-9243-11eb-9b13-01a09a60c93f.png">
