### PR TITLE
fix(register-payment): when unmounting, don't send undefined with firestore data

### DIFF
--- a/src/components/register/register-payment.js
+++ b/src/components/register/register-payment.js
@@ -143,8 +143,8 @@ class RegisterPayment extends Component {
     const isActive = value === 'active';
 
     const updatedForm = {
-      PaypalPayerID: paymentDetails.payerId,
-      PaypalPaymentID: paymentDetails.paymentId,
+      PaypalPayerID: paymentDetails.payerId || '',
+      PaypalPaymentID: paymentDetails.paymentId || '',
       PaymentOption: paymentDetails.paymentId ? 'Paypal' : 'Invoiced',
       AmountPaid: isActive ? '$50.00' : '$30.00',
       invoiceDate: currentDate,


### PR DESCRIPTION
If a user causes the "payment" step of registration to unmount without any Paypal data, it could break the app. This corrects that.