### PR TITLE
fix(members): member info and status now shows correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/pages/members/index.js
+++ b/src/pages/members/index.js
@@ -64,6 +64,7 @@ const MembersHome = ({
         <Helmet>
           <title>TMAC | Members</title>
         </Helmet>
+
         {isAuthenticated ? (
           <MemberContent
             authUser={authUser}

--- a/src/pages/members/member-info.js
+++ b/src/pages/members/member-info.js
@@ -40,6 +40,7 @@ const propTypes = {
     Title: PropTypes.string,
     ZipCode: PropTypes.string,
   }),
+  isRegisteredForCurrentYear: PropTypes.bool.isRequired,
   setShouldRefetchUserList: PropTypes.func.isRequired,
 };
 
@@ -90,6 +91,7 @@ const useStyles = makeStyles((theme) => ({
 // Component Definition
 const MemberInfo = ({
   currentUser,
+  isRegisteredForCurrentYear,
   setShouldRefetchUserList,
 }) => {
   const classes = useStyles();
@@ -199,7 +201,7 @@ const MemberInfo = ({
                 }}
                 primary={(
                   <>
-                    {!currentUser ? 'Inactive' : currentUser?.MemberType || 'Active'} member
+                    {!isRegisteredForCurrentYear ? 'Inactive' : currentUser?.MemberType || 'Active'} member
                   </>
                 )}
                 secondary={`for the ${currentSchoolYearLong} school year`}

--- a/src/pages/members/member-tasks.js
+++ b/src/pages/members/member-tasks.js
@@ -77,7 +77,7 @@ const MemberTasks = ({
       <div className={classes.buttonContainer}>
         <ReactToPrint
           content={() => printInvoiceRef.current}
-          trigger={() => <RegisterButton isRed>Print Invoice</RegisterButton>}
+          trigger={() => <RegisterButton green>Print Invoice</RegisterButton>}
         />
       </div>
 
@@ -106,7 +106,7 @@ const MemberTasks = ({
         <ReactToPrint
           content={() => printReceiptRef.current}
           trigger={() => (
-            <RegisterButton>
+            <RegisterButton green>
               Print Receipt
             </RegisterButton>
           )}


### PR DESCRIPTION
# The issue

- Members are not seeing the correct "active" or "inactive" status

# The solution

- Remove reducer
- Check for user in current member list using `Object.prototype.some()`

# Visuals

Member info and status (and invoice/receipt print) shows up as expected.

<img width="760" alt="image" src="https://user-images.githubusercontent.com/11624407/131726482-f25e4d83-92e9-48f5-b566-b1e2a19c736f.png">

