### PR TITLE
Story/70/change music to fine arts

### DIFF
--- a/src/components/masthead/index.js
+++ b/src/components/masthead/index.js
@@ -1,7 +1,5 @@
 // External Dependencies
 import hex2rgba from 'hex2rgba';
-import React from 'react';
-// import { makeStyles } from '@material-ui/styles';
 
 // Internal Dependencies
 import ArrowForwardIcon from '../shared/ArrowForwardIcon';
@@ -13,13 +11,6 @@ import {
 } from '../../utils/gutters';
 
 // Local Variables
-// const useStyles = makeStyles({
-//   icon: {
-//     transform: 'translateY(8px)',
-//     marginLeft: '0.5em',
-//   },
-// });
-
 const texasFlagBlue = '#002868';
 
 // Component Definition
@@ -99,6 +90,7 @@ const Masthead = () => {
         >
           Texas Music Administrators Conference
         </h1>
+
         <div
           css={{
             color: `${hex2rgba(texasFlagBlue, 0.9)}`,
@@ -106,15 +98,16 @@ const Masthead = () => {
             fontSize: 20,
             marginBottom: '1.5em',
             padding: 0,
-            width: rhythm(5),
+            width: rhythm(7),
             [presets.Tablet]: {
               display: 'block',
-              width: rhythm(12),
+              width: rhythm(13),
             },
           }}
         >
-          Supporting Music Education in Texas
+          Supporting Fine Arts Education in Texas
         </div>
+
         <CtaButton
           buttonColor="blue"
           to="/about/"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -64,24 +64,27 @@ const Home = (props) => {
       <Helmet>
         <title>TMAC | Home</title>
       </Helmet>
+
       <MastheadBg />
+
       <div className={classes.root}>
         <MastheadContent />
+
         <Cards>
           <Card>
             <FuturaParagraph>
-              Greetings from the Texas Music Administrators Conference! The Texas
-              Music Administrators Conference (TMAC) is an organization of
-              music/fine arts administrators with a common goal&mdash;the
-              continued pursuit of excellence in music education in Texas for all
+              <strong>Greetings from the Texas Music Administrators Conference!</strong>{' '}
+              The Texas Music Administrators Conference (TMAC) is an organization of
+              fine arts administrators with a common goal&mdash;the
+              continued pursuit of excellence in fine arts education in Texas for all
               students. While our roles may be varied in our individual school
               districts we stand together to create a supportive environment so
-              that all children in Texas are offered a quality music education.
+              that all children in Texas are offered a quality fine arts education.
             </FuturaParagraph>
             <FuturaParagraph>
-              If you are a music/fine arts administrator, an aspiring
+              If you are a fine arts administrator, an aspiring
               administrator, or if you are responsible for the organizing or
-              supervision of music activities in your district, we encourage you
+              supervision of fine arts activities in your district, we encourage you
               to become a member of TMAC. We meet as a group three times per year and everyone is invited to attend.  We just ask that you first register to be a member of TMAC.  We meet in July in San Antonio during the summer TBA/TODA/TCDA conference, in November in Austin, and in February as part of the TMEA All-State Music Conference. If you would like more information regarding any of these events, please <Link to="/events/fall-retreat/">visit the events page</Link>.
             </FuturaParagraph>
           </Card>

--- a/src/pages/members/join.js
+++ b/src/pages/members/join.js
@@ -79,7 +79,7 @@ const JoinContainer = (props) => {
                 2.
                 {' '}
               </span>
-              Complete the Registration Form.
+              Complete the Membership Form.
             </FuturaDiv>
 
             <FuturaDiv>
@@ -91,9 +91,9 @@ const JoinContainer = (props) => {
             </FuturaDiv>
 
             <p>
-              Note: Sponsors should register at the
+              Note: Sponsors should complete the
               {' '}
-              <Link to="/sponsors">Sponsors page</Link>
+              <Link to="/sponsors">Sponsor Form</Link>
               .
             </p>
           </div>
@@ -108,13 +108,13 @@ const JoinContainer = (props) => {
               buttonColor="blue"
               to="/members/register"
             >
-              Begin Registration
+              Begin Membership
               <ArrowForwardIcon />
             </CtaButton>
           </div>
 
           <div style={{ marginTop: '1.5rem' }}>
-            * Registration is not complete until payment is received.
+            * Membership is not complete until payment is received.
           </div>
         </Container>
 

--- a/src/pages/members/payment.js
+++ b/src/pages/members/payment.js
@@ -78,7 +78,7 @@ class Payment extends Component {
             <div>Radio buttons for active/retired</div>
 
             <div style={{ marginTop: '1.5rem' }}>
-              * Registration is not complete until payment is received.
+              * Membership is not complete until payment is received.
             </div>
           </Container>
 


### PR DESCRIPTION
- Make wording on home page read as `fine arts` instead of only `music`
- Change `registration` to `membership` in several spots