### PR TITLE
refactor: sponsor list for exec secretary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/pages/members/member-content.js
+++ b/src/pages/members/member-content.js
@@ -11,7 +11,11 @@ import React, { useEffect, useMemo, useState } from 'react';
 import EnhancedAlert from '../../components/shared/EnhancedAlert';
 import Cards from '../../components/shared/cards';
 import presets from '../../utils/presets';
-import { ADMIN_USER_EMAIL_LIST, TMAC_WEB_ADMIN_EMAIL_LIST } from '../../utils/member-constants';
+import {
+  ADMIN_USER_EMAIL_LIST,
+  TMAC_WEB_EXECUTIVE_SECRETARY,
+  TMAC_WEB_ADMIN_EMAIL_LIST,
+} from '../../utils/member-constants';
 
 // Local Dependencies
 import MemberFileShareCard from './MemberFileShareCard';
@@ -77,7 +81,10 @@ const MemberContent = ({
   }
 
   const isAdmin = authUser && ADMIN_USER_EMAIL_LIST.includes(authUser.email);
-  const isTMACWebAdmin = authUser && TMAC_WEB_ADMIN_EMAIL_LIST.includes(authUser.email);
+
+  const shouldSeeSponsorListLink = authUser
+    && (TMAC_WEB_ADMIN_EMAIL_LIST.includes(authUser.email)
+    || authUser.email === TMAC_WEB_EXECUTIVE_SECRETARY);
 
   return (
     <div>
@@ -119,7 +126,7 @@ const MemberContent = ({
           ))}
       </Cards>
 
-      {isTMACWebAdmin
+      {shouldSeeSponsorListLink
         ? (
           <Box component="p" mt={4}>
             View the <Link to="/members/sponsor-list">Sponsors</Link> for this year.

--- a/src/pages/members/sponsor-list.js
+++ b/src/pages/members/sponsor-list.js
@@ -14,7 +14,10 @@ import SponsorListTable from './sponsor-table';
 import Status from './status';
 import presets from '../../utils/presets';
 import { doGetUsers } from '../../firebase/db';
-import { TMAC_WEB_ADMIN_EMAIL_LIST } from '../../utils/member-constants';
+import {
+  TMAC_WEB_EXECUTIVE_SECRETARY,
+  TMAC_WEB_ADMIN_EMAIL_LIST,
+} from '../../utils/member-constants';
 
 // Local Variables
 const propTypes = {
@@ -67,9 +70,11 @@ const SponsorListContent = ({
     return null;
   }
 
-  const isTMACWebAdmin = userEmail && TMAC_WEB_ADMIN_EMAIL_LIST.includes(userEmail);
+  const shouldSeeSponsorListLink = userEmail
+    && (TMAC_WEB_ADMIN_EMAIL_LIST.includes(userEmail)
+    || userEmail === TMAC_WEB_EXECUTIVE_SECRETARY);
 
-  if (!isTMACWebAdmin) {
+  if (!shouldSeeSponsorListLink) {
     return <Typography>This data is only available for admin users.</Typography>;
   }
 
@@ -84,7 +89,7 @@ const SponsorListContent = ({
       <div className={classes.paddingContainer}>
         <h2>Sponsor list</h2>
 
-        {isTMACWebAdmin && (
+        {shouldSeeSponsorListLink && (
           <EnhancedAlert
             title="Admin View"
             severity="info"
@@ -95,7 +100,7 @@ const SponsorListContent = ({
 
         <SponsorListTable
           data={Object.values(userData)}
-          isAdmin={isTMACWebAdmin}
+          isAdmin={shouldSeeSponsorListLink}
         />
       </div>
     </div>

--- a/src/pages/members/sponsor-table/index.js
+++ b/src/pages/members/sponsor-table/index.js
@@ -109,7 +109,7 @@ const SponsorTable = ({
   const [order, setOrder] = useState('asc');
   const [orderBy, setOrderBy] = useState('LastName');
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
 
   if (!data) {
     return null;

--- a/src/utils/member-constants.js
+++ b/src/utils/member-constants.js
@@ -1,12 +1,14 @@
 export const ADMIN_USER_EMAIL_LIST = [
   'dinah.menger@fwisd.org',
+  'james.drew@fortbendisd.com',
   'jclark@springisd.org',
-  'jon.lester@abileneisd.org',
   'jeffrey.turner@allenisd.org',
-  'jim.egger@mcallenisd.net',
+  'manuel.gamez@pfisd.net',
   'm2mathew@me.com',
   'mike@drumsensei.com',
 ];
+
+export const TMAC_WEB_EXECUTIVE_SECRETARY = 'jeffrey.turner@allenisd.org';
 
 export const TMAC_WEB_ADMIN_EMAIL_LIST = [
   'm2mathew@me.com',


### PR DESCRIPTION
- Update admin user email addresses
- Add TMAC Executive Secretary to list of people who can see the Sponsors table
- Default Sponsors table to 25 rows of data (which should usually show all sponsors)