### PR TITLE
Fix/add react imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -76,7 +76,7 @@ const StyledRoot = styled.div<StyledRootProps>(({
       paddingLeft: $hasSidebar ? theme.spacing(25) : 0,
     },
     [presets.Desktop]: {
-      paddingLeft: $hasSidebar ? theme.spacing(31.5) : 0,
+      paddingLeft: $hasSidebar ? theme.spacing(38) : 0,
     },
   },
 

--- a/src/components/shared/FormikCheckbox.tsx
+++ b/src/components/shared/FormikCheckbox.tsx
@@ -6,7 +6,7 @@ import {
   FormControlLabel,
 } from '@mui/material';
 import { useField } from 'formik';
-import { FC } from 'react';
+import React, { FC } from 'react';
 import styled from 'styled-components';
 
 // Local Typings


### PR DESCRIPTION
- Add missing React import in `FormikCheckbox`
- Adjust layout's `padding-left` when a sidebar is present on `Desktop` screen size