### PR TITLE
refactor(members): add link to members list; add Dinah Menger past president page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/about/about-constants.ts
+++ b/src/components/about/about-constants.ts
@@ -277,4 +277,8 @@ export const pastPresidents = [
     year: '2021-2022',
     name: 'Joe Clark',
   },
+  {
+    year: '2022-2023',
+    name: 'Dinah Menger',
+  },
 ];

--- a/src/components/members/MemberAuthSwitchRoute.tsx
+++ b/src/components/members/MemberAuthSwitchRoute.tsx
@@ -10,8 +10,6 @@ import NonMemberContent from './NonMemberContent';
 const MemberAuthSwitchRoute: React.FC = () => {
   const { currentAuthUser } = useGetAuthUser();
 
-  console.log('switch route, currentAuthUser', currentAuthUser);
-
   const isAuthenticated = Boolean(currentAuthUser);
 
   if (!isAuthenticated) {

--- a/src/components/members/MemberAuthSwitchRoute.tsx
+++ b/src/components/members/MemberAuthSwitchRoute.tsx
@@ -10,6 +10,8 @@ import NonMemberContent from './NonMemberContent';
 const MemberAuthSwitchRoute: React.FC = () => {
   const { currentAuthUser } = useGetAuthUser();
 
+  console.log('switch route, currentAuthUser', currentAuthUser);
+
   const isAuthenticated = Boolean(currentAuthUser);
 
   if (!isAuthenticated) {

--- a/src/components/members/MemberContent/MemberInfo/MemberActions.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberActions.tsx
@@ -183,6 +183,30 @@ const MemberActions: React.FC<Props> = ({
             </CtaButton>
           </ListItemSecondaryAction>
         </ListItem>
+
+        <ListItem className="listItem">
+          <ListItemText
+            classes={{
+              primary: 'listItemText',
+              secondary: 'listItemSecondaryText',
+            }}
+            primary="View Members List"
+            secondary="See information for registered members for this year."
+          />
+        </ListItem>
+
+        <ListItem className="actionContainer">
+          <ListItemSecondaryAction>
+            <CtaButton
+              colorVariant="resources"
+              fontWeight={500}
+              href="/members/member-list/"
+              width={144}
+            >
+              View
+            </CtaButton>
+          </ListItemSecondaryAction>
+        </ListItem>
       </List>
 
       <DialogUpdateAuthUserEmail

--- a/src/components/members/MemberContent/MemberInfo/MemberActions.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberActions.tsx
@@ -1,4 +1,5 @@
 // External Dependencies
+import { navigate } from 'gatsby';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
@@ -123,6 +124,10 @@ const MemberActions: React.FC<Props> = ({
     }
   }, [newEmailError, newEmailValue, onUpdateShouldRefetchUserList]);
 
+  const handleNavigateToMemberList = useCallback(() => {
+    navigate('/members/member-list');
+  }, []);
+
   return (
     <StyledMemberInfoCard cardTitle="Member actions">
       <List>
@@ -200,7 +205,7 @@ const MemberActions: React.FC<Props> = ({
             <CtaButton
               colorVariant="resources"
               fontWeight={500}
-              href="/members/member-list/"
+              onClick={handleNavigateToMemberList}
               width={144}
             >
               View

--- a/src/components/members/MemberContent/MemberInfo/index.tsx
+++ b/src/components/members/MemberContent/MemberInfo/index.tsx
@@ -44,8 +44,8 @@ const StyledRoot = styled.div(({ theme }) => ({
 
   alignItems: 'center',
   display: 'flex',
-  overflow: 'hidden',
   flexDirection: 'column',
+  overflow: 'hidden',
   padding: theme.spacing(14, 18),
   position: 'relative',
   width: '100%',

--- a/src/components/members/MembersList/MembersListAuthSwitchRoute.tsx
+++ b/src/components/members/MembersList/MembersListAuthSwitchRoute.tsx
@@ -1,0 +1,27 @@
+// External Dependencies
+import React, { useEffect, useState } from 'react';
+
+// Internal Dependencies
+import { useGetAuthUser } from '../../../utils/hooks/useGetAuthUser';
+import MembersListContent from './MembersListContent';
+
+// Component Definition
+const MembersListAuthSwitchRoute: React.FC = () => {
+  const { currentAuthUser } = useGetAuthUser();
+
+  const [renderCount, setRenderCount] = useState(0);
+
+  const isAuthenticated = Boolean(currentAuthUser);
+
+  useEffect(() => {
+    setRenderCount(renderCount + 1);
+  }, []);
+
+  if (!renderCount && !isAuthenticated) {
+    return null;
+  }
+
+  return <MembersListContent currentAuthUser={currentAuthUser} />;
+};
+
+export default MembersListAuthSwitchRoute;

--- a/src/components/shared/PeoplePage.tsx
+++ b/src/components/shared/PeoplePage.tsx
@@ -1,6 +1,5 @@
 // External Dependencies
 import React, { FC } from 'react';
-import { Helmet } from 'react-helmet';
 import styled from 'styled-components';
 
 // Internal Dependencies
@@ -23,7 +22,8 @@ const StyledRoot = styled.div(({ theme }) => ({
     marginBottom: theme.spacing(4),
   },
   '.image': {
-    marginBottom: 0,
+    marginBottom: theme.spacing(2),
+    maxWidth: '50%',
   },
 
   display: 'flex',
@@ -39,11 +39,10 @@ const PeoplePage: FC<Props> = ({
   location,
   name,
 }) => (
-  <Layout location={location}>
-    <Helmet>
-      <title>TMAC | {name}</title>
-    </Helmet>
-
+  <Layout
+    location={location}
+    pageTitle={name}
+  >
     <StyledRoot>
       <Container>
         {imgSrc ? (

--- a/src/components/shared/cards/card-headline.tsx
+++ b/src/components/shared/cards/card-headline.tsx
@@ -11,16 +11,12 @@ interface Props {
   children: React.ReactNode;
   gutterBottom?: boolean;
 }
-interface StyledH2Props {
-  $gutterBottom: boolean;
-}
-
 // Local Variables
-const StyledH2 = styled.h2<StyledH2Props>(({ $gutterBottom, theme }) => ({
+const StyledH2 = styled.h2(({ theme }) => ({
   ...scale(2 / 5),
   lineHeight: 1.2,
   marginTop: 0,
-  marginBottom: $gutterBottom ? 'inherit' : 0,
+  marginBottom: theme.spacing(2),
   [theme.breakpoints.up('mobile')]: {
     fontSize: scale(1 / 10).fontSize,
   },
@@ -36,13 +32,12 @@ const StyledH2 = styled.h2<StyledH2Props>(({ $gutterBottom, theme }) => ({
 }));
 
 // Component Definition
-const CardHeadline: FC<Props> = ({
-  children,
-  gutterBottom = true,
-}) => (
-  <StyledH2 $gutterBottom={gutterBottom}>
-    {children}
-  </StyledH2>
-);
+const CardHeadline: FC<Props> = ({ children }) => {
+  return (
+    <StyledH2>
+      {children}
+    </StyledH2>
+  );
+};
 
 export default CardHeadline;

--- a/src/pages/members/MemberActions.js
+++ b/src/pages/members/MemberActions.js
@@ -197,7 +197,6 @@ const MemberActions = ({
             </Button>
           </ListItemSecondaryAction>
         </ListItem>
-
       </List>
 
       <StyledDialog

--- a/src/pages/members/member-list.js
+++ b/src/pages/members/member-list.js
@@ -5,12 +5,14 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 // Internal Dependencies
+import { ADMIN_USER_EMAIL_LIST } from '../../utils/member-constants';
+import { appNameShort } from '../../utils/app-constants';
+import { doGetUsers } from '../../firebase/db';
+import { useGetAuthUser } from '../../utils/hooks/useGetAuthUser';
 import AuthUserContext from '../../components/session/AuthUserContext';
 import EnhancedAlert from '../../components/shared/EnhancedAlert';
 import Layout from '../../components/layout';
 import MemberListTable from './member-table';
-import { doGetUsers } from '../../firebase/db';
-import { ADMIN_USER_EMAIL_LIST } from '../../utils/member-constants';
 
 // Local Variables
 const propTypes = {
@@ -41,10 +43,9 @@ const StyledRoot = styled.div(({ theme }) => ({
 }));
 
 // Component Definition
-const MemberListContent = ({
-  isAuthenticated,
-  userEmail,
-}) => {
+const MemberListContent = ({ isAuthenticated }) => {
+  const { currentAuthUser } = useGetAuthUser();
+
   const [userData, setUserData] = useState([]);
 
   const handleUpdateUserList = (userList) => {
@@ -61,12 +62,12 @@ const MemberListContent = ({
     return null;
   }
 
-  const isAdmin = userEmail && ADMIN_USER_EMAIL_LIST.includes(userEmail);
+  const isAdmin = Boolean(currentAuthUser && ADMIN_USER_EMAIL_LIST.includes(currentAuthUser.email));
 
   return (
     <StyledRoot>
       <Helmet>
-        <title>TMAC | Member List</title>
+        <title>{appNameShort} | Member List</title>
       </Helmet>
 
       <div className="paddingContainer">

--- a/src/pages/members/member-list.tsx
+++ b/src/pages/members/member-list.tsx
@@ -1,0 +1,44 @@
+// External Dependencies
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+// Internal Dependencies
+import Layout from '../../components/layout';
+import MembersListAuthSwitchRoute from '../../components/members/MembersList/MembersListAuthSwitchRoute';
+
+// Local Typings
+interface Props {
+  location: Location;
+}
+
+// Local Variables
+const StyledRoot = styled.div(({ theme }) =>({
+  '.paddingContainer': {
+    [theme.breakpoints.down('sm')]: {
+      padding: theme.spacing(5, 2, 2),
+    },
+
+    padding: theme.spacing(6, 3, 3),
+  },
+
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  width: '100%',
+}));
+
+// Component Definition
+const MemberList: FC<Props> = ({ location }) => {
+  return (
+    <Layout
+      location={location}
+      pageTitle="Member List"
+    >
+      <StyledRoot>
+        <MembersListAuthSwitchRoute />
+      </StyledRoot>
+    </Layout>
+  );
+};
+
+export default MemberList;

--- a/src/pages/members/member-table/MemberTableRowActionElements.js
+++ b/src/pages/members/member-table/MemberTableRowActionElements.js
@@ -1,13 +1,11 @@
 // External Dependencies
-import {
-  IconButton,
-  Tooltip,
-} from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import PrintIcon from '@mui/icons-material/Print';
 import PropTypes from 'prop-types';
 import React, { useCallback, useRef } from 'react';
 import ReactToPrint from 'react-to-print';
 import ReceiptIcon from '@mui/icons-material/Receipt';
+import Tooltip from '@mui/material/Tooltip';
 import styled from 'styled-components';
 
 // Internal Dependencies
@@ -27,8 +25,8 @@ const defaultProps = {
 
 const StyledRoot = styled.div({
   '.icon': {
-    height: 24,
-    width: 24,
+    height: 28,
+    width: 28,
   },
   '.invoiceWrapper': {
     display: 'none',
@@ -43,7 +41,10 @@ const MemberTableRowActionElements = ({ user }) => {
   const hasInvoice = user && user.PaymentOption && user.PaymentOption.toLowerCase() === 'invoiced';
 
   const handlePrintReceipt = useCallback(() => (
-    <Tooltip title="Print receipt">
+    <Tooltip
+      arrow
+      title="Print Receipt"
+    >
       <IconButton aria-label="Print receipt">
         <ReceiptIcon className="icon" />
       </IconButton>
@@ -51,7 +52,10 @@ const MemberTableRowActionElements = ({ user }) => {
   ), []);
 
   const handlePrintInvoice = useCallback(() => (
-    <Tooltip title="Print invoice">
+    <Tooltip
+      arrow
+      title="Print Invoice"
+    >
       <IconButton aria-label="Print invoice">
         <PrintIcon className="icon" />
       </IconButton>
@@ -81,7 +85,6 @@ const MemberTableRowActionElements = ({ user }) => {
   }
 
   if (hasInvoice) {
-    console.log('has invoice');
     return (
       <StyledRoot key={`print-invoice-${user.userId}`}>
         <ReactToPrint

--- a/src/pages/members/member-table/index.tsx
+++ b/src/pages/members/member-table/index.tsx
@@ -62,12 +62,10 @@ const StyledRoot = styled(Paper)(({ theme }) => ({
 
   '.table': {
     marginBottom: 0,
-    width: 1000,
-    // overflow: 'scroll',
+    // width: 1000,
   },
 
   margin: theme.spacing(3, 0),
-  // width: '100%',
 }));
 
 // Local Functions

--- a/src/pages/members/member-table/index.tsx
+++ b/src/pages/members/member-table/index.tsx
@@ -46,6 +46,7 @@ const StyledRoot = styled(Paper)(({ theme }) => ({
 
   '.overflowWrapper': {
     overflowX: 'auto',
+    width: '100%',
   },
 
   '.pagerButton': {
@@ -65,11 +66,12 @@ const StyledRoot = styled(Paper)(({ theme }) => ({
 
   '.table': {
     marginBottom: 0,
-    minWidth: 200,
+    width: 1000,
+    // overflow: 'scroll',
   },
 
   margin: theme.spacing(3, 0),
-  width: '100%',
+  // width: '100%',
 }));
 
 // Local Functions

--- a/src/pages/members/member-table/index.tsx
+++ b/src/pages/members/member-table/index.tsx
@@ -5,29 +5,25 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import PropTypes from 'prop-types';
 import React, { FC, useState } from 'react';
 import styled from 'styled-components';
 
 // Internal Dependencies
 import { TfaaMemberData } from '../../../utils/hooks/useGetAllMembers'
+import EnhancedAlert from '../../../components/shared/EnhancedAlert';
 import MemberTableHead from './member-table-head';
 import MemberTableRowActionElements from './MemberTableRowActionElements';
 
 // Local Typings
 interface Props {
-  data: TfaaMemberData[];
+  data: TfaaMemberData[] | null;
   isAdmin: boolean;
+  noAuthUser: boolean;
 }
 
 export type Order = 'asc' | 'desc';
 
 // Local Variables
-const propTypes = {
-  data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  isAdmin: PropTypes.bool.isRequired,
-};
-
 const StyledRoot = styled(Paper)(({ theme }) => ({
   '.MuiToolbar-root': {
     display: 'flex',
@@ -103,7 +99,7 @@ function uglifyEmail(email: string) {
   }
   const index = email.indexOf('@');
 
-  // Remove it & insert -at- back in → Array.prototype.splice()
+  // Remove it & insert -at- back in → Array.splice()
   const uglyEmailArray = email.split('');
 
   uglyEmailArray.splice(index, 1, '-at-');
@@ -115,6 +111,7 @@ function uglifyEmail(email: string) {
 const MemberTable: FC<Props> = ({
   data,
   isAdmin,
+  noAuthUser,
 }) => {
   const [order, setOrder] = useState('asc');
   const [orderBy, setOrderBy] = useState('LastName');
@@ -138,6 +135,17 @@ const MemberTable: FC<Props> = ({
     setOrder(isAsc ? 'desc' : 'asc');
     setOrderBy(property);
   };
+
+  if (noAuthUser && !data) {
+    return (
+      <EnhancedAlert
+        severity="info"
+        title="Not Authorized"
+      >
+        Sign in to the view the current member list
+      </EnhancedAlert>
+    );
+  }
 
   if (!data) {
     return null;
@@ -242,7 +250,5 @@ const MemberTable: FC<Props> = ({
     </StyledRoot>
   );
 };
-
-MemberTable.propTypes = propTypes;
 
 export default MemberTable;

--- a/src/pages/resources/people/david-cain.tsx
+++ b/src/pages/resources/people/david-cain.tsx
@@ -34,6 +34,7 @@ const DavidCain: FC<Props> = ({ location }) => (
       Westminster Choir College, San Jose State, and UTSA are a few of the
       places he has had the opportunity of additional training.
     </FuturaParagraph>
+
     <FuturaParagraph>
       David has studied choral music with Dr. Arpad Darazs, Katinka Daniel,
       Robert Shaw, Sir David Willocks, Dr. Charlene Archibeque, Dr. John
@@ -43,11 +44,12 @@ const DavidCain: FC<Props> = ({ location }) => (
       Singers and UTSA Choral Ensembles. He continues to learn and teach at
       each level: children to adults, infants to senior citizens, public
       school to university classroom, All-District Elementary Honor Choir to
-      the Sanctuary Choir at St. Matthew’s United Methodist Church. He has
+      the Sanctuary Choir at St. Matthew&apos;s United Methodist Church. He has
       accompanied singers, choirs, instrumentalists and chamber ensembles on
       the piano. He has directed festivals, operas, musicals and major
       choral works with orchestras.
     </FuturaParagraph>
+
     <FuturaParagraph>
       As an educator, David has mentored many young music educators. He has
       been an officer for the Kodály Educators of Texas. Central Texas Orff

--- a/src/pages/resources/people/david-lambert.tsx
+++ b/src/pages/resources/people/david-lambert.tsx
@@ -33,6 +33,7 @@ const DavidLambert: FC<Props> = ({ location }) => (
       graduate study and certification in school supervision and school
       administration at the University of Houston.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Under his leadership, Fort Bend Independent School district created a
       cadre of exemplary teachers. Over the last twelve years of his tenure
@@ -48,6 +49,7 @@ const DavidLambert: FC<Props> = ({ location }) => (
       direction, the John Foster Dulles High School Band received numerous
       awards in state and national competitions.
     </FuturaParagraph>
+
     <FuturaParagraph>
       He is an active clinician and consultant. The Texas Music
       Administrators Conference named him Texas Music Administrator of the
@@ -64,6 +66,7 @@ const DavidLambert: FC<Props> = ({ location }) => (
       (2009-2011), Executive Secretary for UIL Music Region 17 and Executive
       Secretary for Phi Beta Mu International Bandmasters Fraternity.
     </FuturaParagraph>
+
     <FuturaParagraph>
       He and his wife, Sheryl, have been married for thirty eight years
       (2010). They reside in Missouri City, Texas and have two sons, Jason

--- a/src/pages/resources/people/dinah-menger.tsx
+++ b/src/pages/resources/people/dinah-menger.tsx
@@ -1,0 +1,60 @@
+// External Dependencies
+import React, { FC } from 'react';
+
+// Internal Dependencies
+import CardHeadline from '../../../components/shared/cards/card-headline';
+import FuturaParagraph from '../../../components/shared/futura-paragraph';
+import PeoplePage from '../../../components/shared/PeoplePage';
+import { appName } from '../../../utils/app-constants';
+
+// Local Typings
+interface Props {
+  location: Location;
+}
+
+// Local Variables
+const name = 'Dinah Menger';
+
+// Component Definition
+const DinahMenger: FC<Props> = ({ location }) => (
+  <PeoplePage
+    imgSrc="c_scale,w_738/v1680970374/dinah_menger_square.jpg"
+    location={location}
+    name={name}
+  >
+    <CardHeadline>TMAC Past President, 2022-2023</CardHeadline>
+
+    <FuturaParagraph>
+      Dinah recently retired as the Director of Vocal and Elementary Music for
+      the Fort Worth ISD, overseeing 134 music programs. Prior to her
+      appointment in Fort Worth, Dinah served as conductor/lecturer at Baylor
+      University from 2013-2015 and was the Choir Director at Arlington High
+      School in Arlington, Texas from 1995-2013. Choirs under her direction
+      performed at the 2005 and 2009 TMEA Conventions and the 2007 and
+      2013 national ACDA conventions, as well as several European
+      performance opportunities.
+    </FuturaParagraph>
+
+    <FuturaParagraph>
+      Dinah&apos;s passion for public school education
+      has led her to work in organizations that promote and support equitable
+      fine arts programs for all teachers and their students. She has served in
+      leadership roles in the Texas Music Educators Association, the UIL
+      Prescribed Music Committee, and the Texas Music Adjudicators
+      Association. She currently serves as the Immediate Past President of
+      the {appName}.
+    </FuturaParagraph>
+
+    <FuturaParagraph>
+      Dinah received her BFA
+      from the University of Arizona and her Masters in Conducting from
+      Texas State University. Dinah is a frequent UIL judge, clinician, voice
+      teacher/coach, teacher consultant, and professional development
+      presenter. She and her husband, Christopher, are devoted to their 3
+      children and wonderful spouses, and 3 grandchildren who they spend as
+      much time with as is humanly possible!
+    </FuturaParagraph>
+  </PeoplePage>
+);
+
+export default DinahMenger;

--- a/src/pages/resources/people/george-w.-jones.tsx
+++ b/src/pages/resources/people/george-w.-jones.tsx
@@ -31,6 +31,7 @@ const GeorgeWJones: FC<Props> = ({ location }) => (
       and staffing for Music, Art, Theatre Arts, Dance and Competitive
       Speech. He is a constant advocate for the arts in education.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Prior to assuming this administrative position, he served as a band
       director in Garland for 18 years teaching at Memorial Middle School,
@@ -38,6 +39,7 @@ const GeorgeWJones: FC<Props> = ({ location }) => (
       High School. He is still active as a clinician and adjudicator for
       music programs across the State of Texas.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Mr. Jones is a native of Pekin, Illinois where he was mentored by “The
       Leader of the Band” Lawrence Fogelberg. He holds a Bachelor of Music
@@ -49,6 +51,7 @@ const GeorgeWJones: FC<Props> = ({ location }) => (
       with the Lifetime Administration Achievement Award from the
       Texas Bandmasters Association.
     </FuturaParagraph>
+
     <FuturaParagraph>
       In addition to his duties in the GISD, George has served as conductor
       of the Richardson Community Band since 1983. During his tenure as
@@ -59,6 +62,7 @@ const GeorgeWJones: FC<Props> = ({ location }) => (
       his service as conductor of the RCB. In 2011, the Richardson Arts
       Alliance presented him with the “Lifetime Achievement Award.”
     </FuturaParagraph>
+
     <FuturaParagraph>
       George is married to Donna Jones, a teacher in the Garland ISD, and
       they have two children and one grandson. He retired from Garland ISD

--- a/src/pages/resources/people/henry-schraub.tsx
+++ b/src/pages/resources/people/henry-schraub.tsx
@@ -31,6 +31,7 @@ const HenrySchraub: FC<Props> = ({ location }) => (
       and was the Supervisor of Music and Director of Bands with the
       Weatherford, Texas Independent School District.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Mr. Schraub&apos;s bands were consistent Sweepstakes winners in UIL
       competition, and his Bishop and Weatherford bands ranked third in the
@@ -42,6 +43,7 @@ const HenrySchraub: FC<Props> = ({ location }) => (
       Texas and has served as an adjudicator at the district, regional, area
       and state levels.
     </FuturaParagraph>
+
     <FuturaParagraph>
       He presently serves as the conductor of The Greater Fort Worth
       Community Band. Mr. Schraub received his Bachelor of Music with honors
@@ -52,6 +54,7 @@ const HenrySchraub: FC<Props> = ({ location }) => (
       Bandmasters Association, Phi Mu Alpha, Pi Kappa Lambda, and Phi Beta
       Mu National Honorary Bandmasters Fraternity.
     </FuturaParagraph>
+
     <FuturaParagraph>
       He served as TMEA Region 5 Band Chairman and Region 5 TMEA Chairman.
       He is a Past-President of the Texas Music Educators Association and

--- a/src/pages/resources/people/jan-schronk.tsx
+++ b/src/pages/resources/people/jan-schronk.tsx
@@ -39,11 +39,13 @@ const JanSchronk: FC<Props> = ({ location }) => (
       Smith. Playing the trombone continued during her freshman year in
       college and choir throughout her college career.
     </FuturaParagraph>
+
     <FuturaParagraph>
       At fourteen, Jan began working at a local Corpus Christi radio station
       and at fifteen, she worked in television. Her weekly program,
       Chalktalks with Jan, continued through her sophomore year in college.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Jan attended Southwestern University in Georgetown, Texas on a full
       scholarship. Theatre and English were her majors, but music continued
@@ -51,6 +53,7 @@ const JanSchronk: FC<Props> = ({ location }) => (
       Science from the University of North Texas and her Mid-Management
       Certification from Texas Women&apos;s University in Denton.
     </FuturaParagraph>
+
     <FuturaParagraph>
       After moving to Dallas, Jan accepted a contract with the Dallas
       Independent School District on a Wednesday morning. On Wednesday
@@ -62,6 +65,7 @@ const JanSchronk: FC<Props> = ({ location }) => (
       month. She learned how important it was to work with the music teacher
       during this period.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Jan&apos;s son was born in 1960. Chip works for HBO PPV in New York City as
       Manager-Operations. He has performed with Granbury Opera House and
@@ -73,6 +77,7 @@ const JanSchronk: FC<Props> = ({ location }) => (
       New Jersey. Grandsons Colin and Cooper take viola and piano lessons
       and are the most loved grandsons in the world.
     </FuturaParagraph>
+
     <FuturaParagraph>
       In 1970, Jan began her career with Hurst-Euless-Bedford ISD at Central
       Junior High School. In 1974, she transferred to Trinity High School to
@@ -80,6 +85,7 @@ const JanSchronk: FC<Props> = ({ location }) => (
       Tarrant Community College. As an actress, Jan has performed at TCC,
       Circle Theatre, Casa Manana, and various community theatres.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Jan met her husband, Stacy Schronk, in 1971, when auditioning for a
       role at TCC. Stacy was head of the theatre department at TCC for
@@ -89,6 +95,7 @@ const JanSchronk: FC<Props> = ({ location }) => (
       Opera House, and Lyric Theatre in Oklahoma City. They have been
       married since 1972.
     </FuturaParagraph>
+
     <FuturaParagraph>
       When Jerry Longwell retired as Director of Fine Arts for the HEB
       school district, Jan decided to apply for the position. From 1986 to
@@ -108,6 +115,7 @@ const JanSchronk: FC<Props> = ({ location }) => (
       during the convention. She has served on the UIL Musical Technical
       Committee., and was a member of TMEA, TCDA and TBA.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Jan would like to thank TMEA and the Texas Music Administrators
       Conference for welcoming her into the organizations and supporting her

--- a/src/pages/resources/people/jay-lester.tsx
+++ b/src/pages/resources/people/jay-lester.tsx
@@ -22,6 +22,7 @@ const JayLester: FC<Props> = ({ location }) => (
     name={name}
   >
     <CardHeadline>TMAC Past President, 2019-2020</CardHeadline>
+
     <FuturaParagraph>
       A product of the Abilene public schools, Jay Lester currently
       serves Abilene ISD as Executive Director of Fine Arts. He also serves as the UIL Music
@@ -37,6 +38,7 @@ const JayLester: FC<Props> = ({ location }) => (
       year, Jay co-conducted the Allen Full Orchestra at the Midwest Clinic in Chicago,
       Illinois.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Jay is proud graduate of Cooper High School in Abilene where he graduated with honors
       while participating in golf, band, choir, show choir, theatre, speech, and film club.
@@ -53,6 +55,7 @@ const JayLester: FC<Props> = ({ location }) => (
       In addition, he has participated in workshops at the Conn Selmer Institute, Texas Tech,
       West Texas A&M, UNT, and the Ohio State University.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Mr. Lester has presented workshops for many conferences including the Texas Music
       Educators Association, Texas Bandmasters Association, Texas Orchestra Directors
@@ -63,6 +66,7 @@ const JayLester: FC<Props> = ({ location }) => (
       each year. He has also judged TMEA Honor Band and Orchestra contests at the Area and State
       level. Jay enjoys judging music festivals for Director&apos;s Choice, Peak, and South Coast.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Additionally, Mr. Lester has also been involved with the Texas Art Educators Association,
       the Texas Dance Educators Association, the Texas Theatre Administrators Conference. In
@@ -75,6 +79,7 @@ const JayLester: FC<Props> = ({ location }) => (
       Celebration Orchestra at First Baptist Church in Abilene as well as in orchestra pits for
       local musicals.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Jay serves on the board of directors for the Abilene Teachers Federal Credit Union, the
       Grace Museum, the Paramount Theatre (Chairman), the HSU Cowboy Band Foundation. He is also

--- a/src/pages/resources/people/jd-janda.tsx
+++ b/src/pages/resources/people/jd-janda.tsx
@@ -22,6 +22,7 @@ const JdJanda: FC<Props> = ({ location }) => (
     name={name}
   >
     <CardHeadline>TMAC Past President, 2017-2018</CardHeadline>
+
     <FuturaParagraph>
       JD (John David) Janda is the Director of Fine Arts in Tomball
       ISD, a position he has held since July 2015. In Tomball, Janda supervises the dance,
@@ -33,6 +34,7 @@ const JdJanda: FC<Props> = ({ location }) => (
       career has spanned 38 years - 22 of which were spent in Katy ISD at James E. Taylor High
       School as Director of Bands and Associate Orchestra Director.
     </FuturaParagraph>
+
     <FuturaParagraph>
       Janda was recognized for his outstanding contributions to students lives in 2001 when he
       was named recipient of the “Southwestern Bell - UIL Sponsor Excellence Award” for the
@@ -47,6 +49,7 @@ const JdJanda: FC<Props> = ({ location }) => (
       Texas Music Educators Association, past TMEA State Band Chair and has served multiple
       three-year terms as a member of the UIL State Music Technical Advisory Committee.
     </FuturaParagraph>
+
     <FuturaParagraph>
       JD&apos;s wife of 31 years, Nancy Janda, teaches Algebra at Willow Wood Junior High in Tomball
       ISD. His daughter, Jane Janda Maloy teaches middle school band in Alvin ISD.

--- a/src/pages/resources/people/joe-clark.tsx
+++ b/src/pages/resources/people/joe-clark.tsx
@@ -24,7 +24,35 @@ const JoeClark: FC<Props> = ({ location }) => (
     <CardHeadline>TMAC Past President, 2020-2021</CardHeadline>
 
     <FuturaParagraph>
-      More info coming soon...
+      Dr. Joe Clark is in his 24th year in education and his tenth year as the
+      Director of Performing and Visual Arts for the Spring Independent School
+      District in Houston, Texas. Prior to administration, Dr. Clark served
+      as a band director in several schools in Spring ISD including Spring High
+      School, Bammel Middle School, and Claughton Middle School, as well as,
+      Industrial Jr. High and Industrial High School in Industrial ISD.
+      While in these positions, his ensembles have placed in the State finals,
+      received “Best-in-Class” at concert band and jazz festivals and
+      Sweepstakes at UIL. While at Spring High School, he co-directed Midwest
+      performances in 2008, 2009 and led the Spring High School Jazz Ensemble
+      at the 2010 Midwest Clinic.
+    </FuturaParagraph>
+
+    <FuturaParagraph>
+      As a strong advocate of the fine arts and arts integration, Dr. Clark
+      remains active as a clinician, guest lecturer and mentor for young
+      teachers as well as an active UIL adjudicator. He is also proud to have
+      previously served as a President of the Texas Fine Arts Administrators
+      (TFAA) organizaiton.
+    </FuturaParagraph>
+
+    <FuturaParagraph>
+      Dr. Clark earned his B.M. in music and his M.M. in conducting from Sam
+      Houston State University; and his Ed.D. in Educational Leadership from
+      the University of Houston.  Dr. Clark is a proud member of Phi Beta Mu
+      (Alpha Chapter), Kappa Kappa Psi, Phi Mu Alpha Sinfonia, TMEA, TBA, and
+      TMAA. Joe and his wife Heather reside in Spring, Texas with their
+      7-year-old daughter, Darcy Anne Clark whose favorite color is pink and
+      just put two hands together in her last piano recital!
     </FuturaParagraph>
   </PeoplePage>
 );

--- a/src/utils/hooks/useGetAllMembers.ts
+++ b/src/utils/hooks/useGetAllMembers.ts
@@ -7,6 +7,7 @@ import usePrevious from './usePrevious';
 
 // Local Typings
 interface UseSponsorDataQueryArguments {
+  isAuthenticated?: boolean;
   useTestData?: boolean;
 }
 
@@ -137,9 +138,10 @@ const memberTestData: TfaaMemberData[] = [
 
 // Hook Definition
 export const useGetAllMembers = ({
+  isAuthenticated = true,
   useTestData = false,
 }: UseSponsorDataQueryArguments) => {
-  const [isLoading, setIsLoading] = React.useState(true);
+  const [isLoading, setIsLoading] = React.useState(isAuthenticated);
   const [shouldRefetchUserList, setShouldRefetchUserList] = React.useState(false);
   const [memberData, setMemberData] = React.useState<TfaaMemberData[] | null>(null);
   const previousMemberData = usePrevious(memberData);
@@ -160,7 +162,7 @@ export const useGetAllMembers = ({
 
   // Fetch member data when component mounts
   useEffect(() => {
-    if (!useTestData || shouldRefetchUserList) {
+    if (isAuthenticated && !useTestData || shouldRefetchUserList) {
       const emptyMemberList: TfaaMemberData[] = [];
 
       setIsLoading(true);
@@ -173,15 +175,18 @@ export const useGetAllMembers = ({
     }
     // We do not want to re-run this effect when other values change
   }, [
+    isAuthenticated,
     useTestData,
   ]);
 
   useEffect(() => {
-    if (!useTestData && !previousMemberData && memberData && !shouldRefetchUserList) {
+    if (isAuthenticated && !useTestData && !previousMemberData
+      && memberData && !shouldRefetchUserList) {
       handleUpdateShouldRefetchUserList(false);
       setIsLoading(false);
     }
   }, [
+    isAuthenticated,
     memberData,
     previousMemberData,
     setIsLoading,
@@ -189,7 +194,7 @@ export const useGetAllMembers = ({
     useTestData,
   ]);
 
-  if (useTestData) {
+  if (isAuthenticated && useTestData) {
     return {
       allMembersData: memberTestData,
       handleUpdateShouldRefetchUserList: null,

--- a/src/utils/hooks/useLoadCurrentMemberData.ts
+++ b/src/utils/hooks/useLoadCurrentMemberData.ts
@@ -1,0 +1,48 @@
+// External Dependencies
+import { useEffect, useState } from 'react';
+
+// Internal Dependencies
+import { TfaaMemberData, useGetAllMembers } from './useGetAllMembers';
+import { useGetAuthUser } from './useGetAuthUser';
+
+// Local Variables
+// Flip this to test with fake Member data in local development
+const useTestData = false;
+
+// Hook Definition
+export const useLoadCurrentMemberData = () => {
+  const { currentAuthUser } = useGetAuthUser();
+
+  console.log('IN hook, currentAuthUser', currentAuthUser);
+
+  const [
+    currentMemberData,
+    setCurrentMemberData,
+  ] = useState<TfaaMemberData | null>(null);
+
+  const {
+    allMembersData,
+    isLoading,
+  } = useGetAllMembers({ useTestData });
+
+  useEffect(() => {
+    if (currentAuthUser && allMembersData && allMembersData.length > 0 && !currentMemberData) {
+      const currentMember = allMembersData.find(
+        // We used to use authUser.uid as the unique key in the Firestore
+        // Now we use authUser.email
+        // We have to search for both for backwards compatibility
+        (user) => {
+          console.log('user', user);
+
+          return user.userId === currentAuthUser.uid || user.userId === currentAuthUser.email;
+        });
+
+      setCurrentMemberData(currentMember ?? null);
+    }
+  }, [currentAuthUser, currentMemberData, isLoading]);
+
+  return {
+    currentMemberData,
+    isLoading,
+  };
+};

--- a/src/utils/hooks/useLoadCurrentMemberData.ts
+++ b/src/utils/hooks/useLoadCurrentMemberData.ts
@@ -13,8 +13,6 @@ const useTestData = false;
 export const useLoadCurrentMemberData = () => {
   const { currentAuthUser } = useGetAuthUser();
 
-  console.log('IN hook, currentAuthUser', currentAuthUser);
-
   const [
     currentMemberData,
     setCurrentMemberData,
@@ -32,8 +30,6 @@ export const useLoadCurrentMemberData = () => {
         // Now we use authUser.email
         // We have to search for both for backwards compatibility
         (user) => {
-          console.log('user', user);
-
           return user.userId === currentAuthUser.uid || user.userId === currentAuthUser.email;
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6235,15 +6235,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001317:
-  version "1.0.30001412"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz"
-  integrity sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==
-
-caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426:
-  version "1.0.30001431"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz#e7c59bd1bc518fae03a4656be442ce6c4887a795"
-  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426:
+  version "1.0.30001474"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz"
+  integrity sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- Update `browserlists` in `yarn.lock` file
- Show link to members list from the authenticated "MembersContent" page
- Convert old `MembersList` to TypeScript
  - Add a "Back to Member Content" button
- Restructure the `MembersList` so that it can use the React context for the authenticated user.
  - Add a "switch" component that's only purpose is to check for an authenticated user and pass it on. I decided not to do a redirect but just didn't remove the component. `¯\_(ツ)_/¯`
- Add a non-authed state to the `MembersTable` component
- In the shared `CardHeadline` component, remove the unused `gutterBottom` prop and always apply margin-bottom spacing
- Add bio info for Joe Clark.
- Add "People" page for Dinah Menger, linked from the Past Presidents page.