### PR TITLE
Fix/hide invoice wording if member paid by check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/members/MemberContent/MemberInfo/MemberRegistrationTasks.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberRegistrationTasks.tsx
@@ -79,7 +79,8 @@ const MemberRegistrationTasks: React.FC<Props> = ({ currentMemberData }) => {
 
   const needsToPay = !currentMemberData?.AmountPaid;
 
-  const isPaypal = currentMemberData?.PaymentOption.toLowerCase() === 'paypal';
+  const canPrintReceipt = currentMemberData?.PaymentOption.toLowerCase() === 'paypal'
+    || currentMemberData?.PaypalPaymentID;
 
   const successIconElement = useMemo(() => (
     <CheckCircleIcon
@@ -186,7 +187,7 @@ const MemberRegistrationTasks: React.FC<Props> = ({ currentMemberData }) => {
           </>
         )}
 
-        {isPaypal && (
+        {canPrintReceipt && (
           <>
             <ListItem className="paymentListItem">
               <ListItemText
@@ -201,7 +202,7 @@ const MemberRegistrationTasks: React.FC<Props> = ({ currentMemberData }) => {
             <ListItem className="actionContainer">
               <ListItemSecondaryAction>
                 <ReactToPrint
-                  content={() => printReceiptRef.current}
+                  content={() => printReceiptRef.current as any}
                   trigger={() => (
                     <CtaButton
                       colorVariant="resources"
@@ -217,7 +218,7 @@ const MemberRegistrationTasks: React.FC<Props> = ({ currentMemberData }) => {
         )}
       </List>
 
-      {isPaypal && (
+      {canPrintReceipt && (
         <div className="hidden">
           <Invoice
             amount={currentMemberData.AmountPaid}
@@ -225,7 +226,7 @@ const MemberRegistrationTasks: React.FC<Props> = ({ currentMemberData }) => {
             isActive={currentMemberData.MemberType === 'Active'}
             isInvoice={false}
             receiptId={currentMemberData.receiptId}
-            ref={printReceiptRef}
+            ref={printReceiptRef as any}
           />
         </div>
       )}

--- a/src/components/members/MemberContent/MemberInfo/MemberStatus.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberStatus.tsx
@@ -106,7 +106,10 @@ const StyledStrong = styled.strong(({ theme }) => ({
 const MemberStatus: React.FC<Props> = ({ currentMemberData }) => {
   const isRegisteredForCurrentYear = Boolean(currentMemberData);
 
-  const isInvoiced = currentMemberData?.PaymentOption.toLowerCase() === 'invoiced';
+  // If the member paid by check, Jeff Turner TFAA Executive Secretary will manually
+  //  add the check number in the PaypalPaymentID field
+  const isInvoiced = currentMemberData?.PaymentOption.toLowerCase() === 'invoiced'
+    && !currentMemberData?.PaypalPaymentID;
 
   const needsToPay = !currentMemberData?.AmountPaid;
 

--- a/src/pages/members/PrintInvoiceUI.js
+++ b/src/pages/members/PrintInvoiceUI.js
@@ -6,7 +6,6 @@ import ReactToPrint from 'react-to-print';
 // Internal Dependencies
 import CtaButton from '../../components/shared/CtaButton';
 import Invoice from '../../components/register/invoice';
-import RegisterButton from '../../components/register/register-button';
 
 // Local Variables
 const propTypes = {

--- a/src/pages/members/member-table/MemberTableRowActionElements.js
+++ b/src/pages/members/member-table/MemberTableRowActionElements.js
@@ -37,8 +37,10 @@ const StyledRoot = styled.div({
 const MemberTableRowActionElements = ({ user }) => {
   const componentRef = useRef();
 
-  const hasReceipt = user && user.PaymentOption && user.PaymentOption.toLowerCase() === 'paypal';
-  const hasInvoice = user && user.PaymentOption && user.PaymentOption.toLowerCase() === 'invoiced';
+  const hasReceipt = user?.PaymentOption?.toLowerCase() === 'paypal'
+    || user?.PaypalPaymentID;
+  const hasInvoice = user?.PaymentOption?.toLowerCase() === 'invoiced'
+    && !user?.PaypalPaymentID;
 
   const handlePrintReceipt = useCallback(() => (
     <Tooltip


### PR DESCRIPTION
Start checking the user data for the value `PaypalPaymentID`. The TFAA Executive Secretary Jeff Turner uses this field to add if a member has paid by check.

Now we will check that to show an invoice versus a receipt in a few areas.

Before | After
--- | ---
<img width="655" alt="image" src="https://user-images.githubusercontent.com/11624407/233106238-3fc9bdec-69fb-42ba-bc1d-7f452b2a457b.png"> | <img width="645" alt="image" src="https://user-images.githubusercontent.com/11624407/233106188-9ea8d4ca-090b-4d21-9932-589617510641.png">
<img width="644" alt="image" src="https://user-images.githubusercontent.com/11624407/233106316-ea7e962d-a5e6-4cdc-9465-484e73e691c6.png"> | <img width="521" alt="image" src="https://user-images.githubusercontent.com/11624407/233106385-c1a8860c-1c38-4068-8598-884532372fa6.png">



