### PR TITLE
2.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/about/PeopleItem.tsx
+++ b/src/components/about/PeopleItem.tsx
@@ -1,4 +1,5 @@
 // External Dependencies
+import { Link } from 'gatsby-theme-material-ui';
 import Typography from '@mui/material/Typography';
 import React, { FC } from 'react';
 import styled from 'styled-components';
@@ -64,7 +65,9 @@ const PeopleItem: FC<Props> = ({ peopleData }) => {
         </Typography>
 
         <Typography className="peopleName">
-          {peopleData.name}
+          <Link href={`mailto:${peopleData.email}`}>
+            {peopleData.name}
+          </Link>
         </Typography>
 
         <Typography variant="body2">


### PR DESCRIPTION
- Add Officer and Area Rep email links on name text

We will now match the same UI as the V2 site.

V2 | V3
--- | ---
<img width="826" alt="image (4)" src="https://user-images.githubusercontent.com/11624407/233470450-a8be5a3d-6732-4b8b-adbb-78f8b2fc8f2a.png"> | <img width="868" alt="image" src="https://user-images.githubusercontent.com/11624407/233470401-b54cea84-e04f-4dd4-8006-443a350fca99.png"> 
