### PR TITLE
Fix/move july 1 to august 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/about/History.tsx
+++ b/src/components/about/History.tsx
@@ -9,7 +9,6 @@ import Motifs from '../shared/Motifs';
 
 // Local Variables
 const StyledRoot = styled.section(({ theme }) => ({
-
   address: {
     '& > p': {
       fontWeight: 500,

--- a/src/components/register/MemberRegisterContent.tsx
+++ b/src/components/register/MemberRegisterContent.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useReducer } from 'react';
 import styled from 'styled-components';
 
 // Internal Dependencies
-import { isTodayAfterJune30th } from '../../utils/helpers';
+import { isTodayAfterJuly31st } from '../../utils/helpers';
 import { useGetAuthUser } from '../../utils/hooks/useGetAuthUser';
 import Container from '../shared/container';
 import RegisterEmail from './RegisterEmail';
@@ -212,8 +212,11 @@ const MemberRegisterContent: React.FC = () => {
 
   const hasCompletedAllMemberSteps = completedMemberSteps.length >= 3;
 
-  // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
-  const showMembershipCompleteNote = isTodayAfterJune30th;
+  console.log('isTodayAfterJuly31st', isTodayAfterJuly31st);
+
+  // We normally shut down registration and sponsorship after TMEA each year and open it up on 8/1.
+  // This might change, so we need to talk to the Executive Secretary for the most up-to-date info.
+  const showMembershipCompleteNote = isTodayAfterJuly31st;
 
   /* Children change depending on which step is active */
   return (

--- a/src/components/register/RegisterEmail.tsx
+++ b/src/components/register/RegisterEmail.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 // Internal Dependencies
 import { appNameShort } from '../../utils/app-constants';
-import { isTodayAfterJune30th } from '../../utils/helpers';
+import { isTodayAfterJuly31st } from '../../utils/helpers';
 import { MemberFormValues } from './MemberRegisterContent';
 import { SponsorFormValues } from './SponsorRegisterContent';
 import FormDivider from '../shared/FormDivider';
@@ -84,7 +84,7 @@ const RegisterEmail: React.FC<Props> = ({
   ]);
 
   // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
-  if (!isTodayAfterJune30th) {
+  if (!isTodayAfterJuly31st) {
     return <RegistrationPausedAlert />;
   }
 

--- a/src/components/register/RegisterStepper.tsx
+++ b/src/components/register/RegisterStepper.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 
 // Internal Dependencies
 import { appNameShort } from '../../utils/app-constants';
-import { isTodayAfterJune30th } from '../../utils/helpers';
+import { isTodayAfterJuly31st } from '../../utils/helpers';
 import DrumBanner from '../shared/DrumBanner';
 import EnhancedCard from '../shared/EnhancedCard';
 
@@ -102,7 +102,7 @@ const RegisterStepper: React.FC<Props> = ({
   const steps = getSteps(isAuthenticated, isViewingSponsors);
 
   // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
-  if (!isTodayAfterJune30th) {
+  if (!isTodayAfterJuly31st) {
     return <DrumBanner drumBannerTitle="Registration Closed" />;
   }
 

--- a/src/components/register/register-member-form-wrapper.tsx
+++ b/src/components/register/register-member-form-wrapper.tsx
@@ -7,7 +7,7 @@ import {
   MemberFormValues,
 } from './MemberRegisterContent';
 import { appNameShort } from '../../utils/app-constants';
-import { isTodayAfterJune30th } from '../../utils/helpers';
+import { isTodayAfterJuly31st } from '../../utils/helpers';
 import FormDivider from '../shared/FormDivider';
 import FormTitle from '../shared/FormTitle';
 import RegisterForm from './register-member-form';
@@ -31,7 +31,7 @@ const MemberFormValuesWrapper: React.FC<Props> = ({
   }
 
   // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
-  const showMembershipForm = isTodayAfterJune30th;
+  const showMembershipForm = isTodayAfterJuly31st;
 
   if (!showMembershipForm) {
     return <RegistrationPausedAlert />;

--- a/src/components/shared/RegistrationPausedAlert.tsx
+++ b/src/components/shared/RegistrationPausedAlert.tsx
@@ -16,7 +16,7 @@ const RegistrationPausedAlert: React.FC<Props> = ({ isMembership = true }) => {
   return (
     <Box mt={3}>
       <EnhancedAlert title={`${type} Notice`}>
-        {appNameShort} {type} will open up again on July 1st.
+        {appNameShort} {type} will open up again on August 1st.
       </EnhancedAlert>
     </Box>
   );

--- a/src/pages/members/join.js
+++ b/src/pages/members/join.js
@@ -7,7 +7,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 // Internal Dependencies
-import { isTodayAfterJune30th } from '../../utils/helpers';
+import { isTodayAfterJuly31st } from '../../utils/helpers';
 import ArrowForwardIcon from '../../components/shared/ArrowForwardIcon';
 import AuthUserContext from '../../components/session/AuthUserContext';
 import CardHeadline from '../../components/shared/cards/card-headline';
@@ -56,11 +56,11 @@ const JoinContainer = ({ location }) => {
           <div className="topContent">
             <CardHeadline>Join TMAC</CardHeadline>
 
-            {!isTodayAfterJune30th
+            {!isTodayAfterJuly31st
               ? (
                 <Box mt={3}>
                   <EnhancedAlert title="Membership Notice">
-                    TMAC Membership will open up again on July 1st.
+                    TMAC Membership will open up again on August 1st.
                   </EnhancedAlert>
                 </Box>
               ) : (
@@ -103,7 +103,7 @@ const JoinContainer = ({ location }) => {
               )}
           </div>
 
-          {isTodayAfterJune30th && (
+          {isTodayAfterJuly31st && (
             <>
               <div className="bottomContent">
                 <CtaButton

--- a/src/pages/members/login.tsx
+++ b/src/pages/members/login.tsx
@@ -43,6 +43,7 @@ const StyledRoot = styled.div(({ theme }) => ({
   flexDirection: 'column',
   flexWrap: 'wrap',
   justifyContent: 'space-around',
+  overflow: 'hidden',
   position: 'relative',
   width: '100vw',
 }));
@@ -66,11 +67,10 @@ const Login: React.FC<Props> = ({ location }) => {
     >
       <ReCaptchaProvider>
         <StyledRoot>
-          <Motifs small />
-
           <DrumBanner drumBannerTitle="Member Log In" />
 
           <div className="loginContent">
+            <Motifs small />
 
             <Typography
               className="loginTitle"

--- a/src/pages/sponsors/sponsor-info.tsx
+++ b/src/pages/sponsors/sponsor-info.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 // Internal Dependencies
 import { appNameShort } from '../../utils/app-constants';
-import { isTodayAfterJune30th } from '../../utils/helpers';
+import { isTodayAfterJuly31st } from '../../utils/helpers';
 import Container from '../../components/shared/container';
 import CtaButton from '../../components/shared/CtaButton';
 import Layout from '../../components/layout';
@@ -42,7 +42,7 @@ const StyledRoot = styled.div(({ theme }) => ({
 // Component Definition
 const SponsorInfo: React.FC<Props> = ({ location }) => {
   // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
-  const showSponsorshipInfo = isTodayAfterJune30th;
+  const showSponsorshipInfo = isTodayAfterJuly31st;
 
   return (
     <Layout

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -45,19 +45,26 @@ export const currentYearShort = format(new Date(), 'yy');
 
 // The "year" for TMAC starts on 7/1
 // new Date(2021, 6, 1) → 7/1/2021
-export const isTodayAfterJune30th = isAfter(
+// export const isTodayAfterJune30th = isAfter(
+//   new Date(),
+//   new Date(parseInt(currentYearLong, 10), 6, 1),
+// );
+
+// As of 2023-06-28, the "year" for TMAC starts on 8/1
+// new Date(2023, 7, 1) → 8/1/2023
+export const isTodayAfterJuly31st = isAfter(
   new Date(),
-  new Date(parseInt(currentYearLong, 10), 6, 1),
+  new Date(parseInt(currentYearLong, 10), 7, 1),
 );
 
-export const currentSchoolYearShort = isTodayAfterJune30th
+export const currentSchoolYearShort = isTodayAfterJuly31st
   ? `${currentYearShort}-${Number(currentYearShort) + 1}`
   : `${Number(currentYearShort) - 1}-${currentYearShort}`;
 
-export const currentSchoolYearLong = isTodayAfterJune30th
+export const currentSchoolYearLong = isTodayAfterJuly31st
   ? `${currentYearLong}-${Number(currentYearLong) + 1}`
   : `${Number(currentYearLong) - 1}-${currentYearLong}`;
 
-export const currentSchoolYearEnding = isTodayAfterJune30th
+export const currentSchoolYearEnding = isTodayAfterJuly31st
   ? `${Number(currentYearLong) + 1}`
   : currentYearLong;


### PR DESCRIPTION
- Switch the date logic to point at 8/1 instead of 7/1 to show current year sponsors and members. This also prevents sign ups until the organization is ready for them, closer to the end of July.
- Adjust the layout and where we render the `<Motifs>` component on the login page. It was overflowing it's container and not showing the whole motif on either side.