### PR TITLE
chore: bump version to 2.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"


### PR DESCRIPTION
Forgot the version bump