### PR TITLE
Refactor/registration revamp with extra fee

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This website was constructed for Jeff Turner, Mario Luna, and the Texas Music Ad
 
 Starting in November 2022, a new design was built by Luis Velasquez at [LV Branding](https://www.lvbranding.com/). The new design launched in early February 2023.
 
+In July 2023 Peter Warshaw took over as the TFAA Executive Secretary.
+
 ## Tools
 
 - GatsbyJS

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/members/MemberContent/MemberInfo/MemberActions.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberActions.tsx
@@ -181,7 +181,7 @@ const MemberActions: React.FC<Props> = ({
             <CtaButton
               colorVariant="resources"
               fontWeight={500}
-              href="mailto:jeffrey.turner@allenisd.org"
+              href="mailto:petwar1@yahoo.com"
               width={144}
             >
               Email {appNameShort}

--- a/src/components/members/MemberContent/MemberInfo/MemberStatus.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberStatus.tsx
@@ -106,7 +106,7 @@ const StyledStrong = styled.strong(({ theme }) => ({
 const MemberStatus: React.FC<Props> = ({ currentMemberData }) => {
   const isRegisteredForCurrentYear = Boolean(currentMemberData);
 
-  // If the member paid by check, Jeff Turner TFAA Executive Secretary will manually
+  // If the member paid by check, the TFAA Executive Secretary will manually
   //  add the check number in the PaypalPaymentID field
   const isInvoiced = currentMemberData?.PaymentOption.toLowerCase() === 'invoiced'
     && !currentMemberData?.PaypalPaymentID;

--- a/src/components/register/MemberRegisterContent.tsx
+++ b/src/components/register/MemberRegisterContent.tsx
@@ -235,7 +235,7 @@ const MemberRegisterContent: React.FC = () => {
         )}
         {activeMemberStep === 1 && (
           <RegisterMemberFormWrapper
-            authenticatedUserId={currentAuthUser?.email}
+            authenticatedUserId={`${currentAuthUser?.email}-${currentAuthUser?.uid}`}
             initialMemberFormValues={INITIAL_MEMBER_FORM_VALUES}
             onCompleteMemberStep={handleCompleteMemberStep}
           />

--- a/src/components/register/MemberRegisterContent.tsx
+++ b/src/components/register/MemberRegisterContent.tsx
@@ -16,7 +16,7 @@ import RegisterStepper from './RegisterStepper';
 export interface MemberFormValues {
   Address1: string;
   Address2?: string;
-  AmountPaid: 0 | 30 | 50;
+  AmountPaid: 0 | 30 | 75;
   CellPhone: string;
   City: string;
   District: string;
@@ -216,6 +216,8 @@ const MemberRegisterContent: React.FC = () => {
   // This might change, so we need to talk to the Executive Secretary for the most up-to-date info.
   const showMembershipCompleteNote = isTodayAfterJuly31st;
 
+  const userId = `${currentAuthUser?.email}-${currentAuthUser?.uid}`;
+
   /* Children change depending on which step is active */
   return (
     <StyledRoot>
@@ -235,14 +237,14 @@ const MemberRegisterContent: React.FC = () => {
         )}
         {activeMemberStep === 1 && (
           <RegisterMemberFormWrapper
-            authenticatedUserId={`${currentAuthUser?.email}-${currentAuthUser?.uid}`}
+            authenticatedUserId={userId}
             initialMemberFormValues={INITIAL_MEMBER_FORM_VALUES}
             onCompleteMemberStep={handleCompleteMemberStep}
           />
         )}
         {[2, 3].includes(activeMemberStep) && (
           <RegisterMemberPayment
-            authenticatedUserId={currentAuthUser?.email}
+            authenticatedUserId={userId}
             onCompleteMemberStep={handleCompleteMemberStep}
             onUpdateMemberForm={handleUpdateMemberForm}
             memberForm={memberForm}

--- a/src/components/register/MemberRegisterContent.tsx
+++ b/src/components/register/MemberRegisterContent.tsx
@@ -212,8 +212,6 @@ const MemberRegisterContent: React.FC = () => {
 
   const hasCompletedAllMemberSteps = completedMemberSteps.length >= 3;
 
-  console.log('isTodayAfterJuly31st', isTodayAfterJuly31st);
-
   // We normally shut down registration and sponsorship after TMEA each year and open it up on 8/1.
   // This might change, so we need to talk to the Executive Secretary for the most up-to-date info.
   const showMembershipCompleteNote = isTodayAfterJuly31st;
@@ -221,10 +219,12 @@ const MemberRegisterContent: React.FC = () => {
   /* Children change depending on which step is active */
   return (
     <StyledRoot>
-      <RegisterStepper
-        isAuthenticated={isAuthenticated}
-        activeStep={activeMemberStep}
-      />
+      {isAuthenticated && (
+        <RegisterStepper
+          isAuthenticated={isAuthenticated}
+          activeStep={activeMemberStep}
+        />
+      )}
 
       <Container>
         {activeMemberStep === 0 && (

--- a/src/components/register/RegisterEmail.tsx
+++ b/src/components/register/RegisterEmail.tsx
@@ -83,7 +83,7 @@ const RegisterEmail: React.FC<Props> = ({
     viewingSignUp,
   ]);
 
-  // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
+  // We normally shut down registration and sponsorship after TMEA each year and open it up on 8/1
   if (!isTodayAfterJuly31st) {
     return <RegistrationPausedAlert />;
   }
@@ -91,7 +91,7 @@ const RegisterEmail: React.FC<Props> = ({
   return (
     <section>
       <FormTitle>
-        1. Sign up for {appNameShort} website login
+        Sign up for {appNameShort} website login
       </FormTitle>
 
       {dividerElement}

--- a/src/components/register/RegisterStepper.tsx
+++ b/src/components/register/RegisterStepper.tsx
@@ -26,14 +26,14 @@ function getSteps(
 ): string[] {
   return [
     isAuthenticated
-      ? `Sign in to the ${appNameShort} members area`
+      ? `${appNameShort} membership type`
       : `Sign up for ${appNameShort} website login`,
     isViewingSponsors
-      ? 'Complete sponsor form'
-      : 'Complete membership form',
+      ? 'Sponsor Info'
+      : 'Member Info',
     isViewingSponsors
       ? 'Confirm Sponsor level and send payment'
-      : `Pay ${appNameShort} dues`,
+      : 'Payment or Invoice',
   ];
 }
 
@@ -101,7 +101,7 @@ const RegisterStepper: React.FC<Props> = ({
 }) => {
   const steps = getSteps(isAuthenticated, isViewingSponsors);
 
-  // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
+  // We normally shut down registration and sponsorship after TMEA each year and open it up on 8/1
   if (!isTodayAfterJuly31st) {
     return <DrumBanner drumBannerTitle="Registration Closed" />;
   }

--- a/src/components/register/RegisterStepper.tsx
+++ b/src/components/register/RegisterStepper.tsx
@@ -26,14 +26,14 @@ function getSteps(
 ): string[] {
   return [
     isAuthenticated
-      ? `${appNameShort} membership type`
-      : `Sign up for ${appNameShort} website login`,
+      ? `${appNameShort} Website Login`
+      : `${appNameShort} Sponsor Level`,
     isViewingSponsors
       ? 'Sponsor Info'
       : 'Member Info',
     isViewingSponsors
-      ? 'Confirm Sponsor level and send payment'
-      : 'Payment or Invoice',
+      ? 'Confirm Sponsor Level & Send Payment'
+      : 'Make Payment or Get Invoice',
   ];
 }
 

--- a/src/components/register/SponsorRegisterContent.tsx
+++ b/src/components/register/SponsorRegisterContent.tsx
@@ -225,7 +225,8 @@ const SponsorRegisterContent: React.FC = () => {
           isAuthenticated={isAuthenticated}
           isViewingSponsors
           activeStep={activeStep}
-        />)}
+        />
+      )}
 
       <Container>
         {activeStep === 0 && (
@@ -236,7 +237,7 @@ const SponsorRegisterContent: React.FC = () => {
         )}
         {activeStep === 1 && (
           <RegisterSponsorFormWrapper
-            authenticatedUserId={currentAuthUser?.uid}
+            authenticatedUserId={`${currentAuthUser?.email}-${currentAuthUser?.uid}`}
             initialSponsorFormValues={INITIAL_SPONSOR_FORM_VALUES}
             onCompleteSponsorStep={handleCompleteSponsorStep}
             onUpdateSponsorForm={handleUpdateSponsorForm}

--- a/src/components/register/SponsorRegisterContent.tsx
+++ b/src/components/register/SponsorRegisterContent.tsx
@@ -220,11 +220,12 @@ const SponsorRegisterContent: React.FC = () => {
   /* Children change depending on which step is active */
   return (
     <StyledRoot>
-      <RegisterStepper
-        isAuthenticated={isAuthenticated}
-        isViewingSponsors
-        activeStep={activeStep}
-      />
+      {isAuthenticated && (
+        <RegisterStepper
+          isAuthenticated={isAuthenticated}
+          isViewingSponsors
+          activeStep={activeStep}
+        />)}
 
       <Container>
         {activeStep === 0 && (

--- a/src/components/register/invoice-table.tsx
+++ b/src/components/register/invoice-table.tsx
@@ -1,14 +1,12 @@
 // External Dependencies
 import React, { useMemo } from 'react';
-import {
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-} from '@mui/material';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
 import styled from 'styled-components';
 
 // Internal Dependencies
@@ -70,7 +68,7 @@ const StyledTableContainer = styled(TableContainer)(({
   marginRight: 32,
   marginTop: theme.spacing(2),
   width: '75%',
-}));
+})) as typeof TableContainer;
 
 // Component Definition
 const InvoiceTable: React.FC<Props> = ({
@@ -85,6 +83,8 @@ const InvoiceTable: React.FC<Props> = ({
   const updatedAmount = amount === 0 ? 50 : amount;
   const formattedAmount = isString ? updatedAmount : `$${Number(updatedAmount)?.toFixed(2).toLocaleString()}`;
 
+  const hasAddedFallConferenceFee = Number(amount) > 100;
+
   const sponsorInfo = useMemo(() => (
     <span>
       {appNameShort} {sponsorLevel} Sponsor donation amount{' '}
@@ -95,9 +95,10 @@ const InvoiceTable: React.FC<Props> = ({
   const memberInfo = useMemo(() => (
     <span>
       {appNameShort} {isActive || !form.MemberType ? 'Active' : 'Retired'} membership fee{' '}
+      {hasAddedFallConferenceFee && 'and Fall Conference registration fee'}
       <br />for <strong>{form.FirstName} {form.LastName}</strong>
     </span>
-  ), [form.FirstName, form.LastName, form.MemberType, isActive]);
+  ), [form.FirstName, form.LastName, form.MemberType, hasAddedFallConferenceFee, isActive]);
 
   return (
     <StyledTableContainer component={Paper}>

--- a/src/components/register/invoice.js
+++ b/src/components/register/invoice.js
@@ -176,12 +176,10 @@ class Invoice extends Component {
                 <strong>{appName}</strong>
               </div>
 
-              <div>c/o Jeff Turner</div>
+              <div>c/o Peter Warshaw</div>
               <div>{appNameShort} Executive Secretary</div>
-              <div>Allen ISD</div>
-              <div>Fine Arts Dept.</div>
-              <div>300 Rivercrest Blvd. </div>
-              <div>Allen, TX 75002</div>
+              <div>4107 Natural Bridge Court</div>
+              <div>Round Rock, TX. 78681</div>
             </div>
 
             <div>

--- a/src/components/register/paypal/paypal-button-wrapper.tsx
+++ b/src/components/register/paypal/paypal-button-wrapper.tsx
@@ -78,7 +78,7 @@ const PaypalButtonWrapper: FC<Props> = ({
       button again.
       <br />
       You can also print an invoice and
-      send payment to the {appNameShort} Treasurer.
+      send payment to the {appNameShort} Executive Secretary.
     </>
   );
 

--- a/src/components/register/register-member-form-wrapper.tsx
+++ b/src/components/register/register-member-form-wrapper.tsx
@@ -30,7 +30,7 @@ const MemberFormValuesWrapper: React.FC<Props> = ({
     return null;
   }
 
-  // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
+  // We normally shut down registration and sponsorship after TMEA each year and open it up on 8/1
   const showMembershipForm = isTodayAfterJuly31st;
 
   if (!showMembershipForm) {

--- a/src/components/register/register-member-payment.tsx
+++ b/src/components/register/register-member-payment.tsx
@@ -120,6 +120,17 @@ const RegisterMemberPayment: React.FC<Props> = ({
 
   const handleToogleHasFallConferenceFee = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setHasFallConferenceFee(event.target.checked);
+
+    const updatedMemberForm = {
+      ...memberForm,
+      IsRegisteredForFallConference: event.target.checked,
+    };
+
+    return doUpdateEntry(
+      updatedMemberForm,
+      FIRESTORE_MEMBER_COLLECTION,
+      authenticatedUserId,
+    );
   }, []);
 
   const handleGetCurrentInvoiceId = useCallback((currentInvoiceId: number) => {
@@ -217,7 +228,7 @@ const RegisterMemberPayment: React.FC<Props> = ({
     handleCompleteMemberPaymentStep(payment);
   }, [handleCompleteMemberPaymentStep, handleGetCurrentReceiptId]);
 
-  const handleChangeRadioSelection = useCallback((event) => {
+  const handleChangeRadioSelection = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const { value: updatedActiveMemberSelection } = event.target;
 
     const isActive = updatedActiveMemberSelection === 'active';
@@ -230,7 +241,7 @@ const RegisterMemberPayment: React.FC<Props> = ({
       receiptId,
     };
 
-    setIsActiveMember(updatedActiveMemberSelection);
+    setIsActiveMember(updatedActiveMemberSelection as ActiveMemberRadioOptions);
     onUpdateMemberForm(updatedMemberForm);
 
     return doUpdateEntry(

--- a/src/components/register/register-member-payment.tsx
+++ b/src/components/register/register-member-payment.tsx
@@ -1,17 +1,18 @@
 // External Dependencies
-import {
-  Box,
-  Card,
-  FormControl,
-  FormControlLabel,
-  Radio,
-  RadioGroup,
-  Typography,
-} from '@mui/material';
 import React, {
   ReactInstance, useCallback, useEffect, useRef, useState
 } from 'react';
+import { alpha } from '@mui/material/styles';
 import ReactToPrint from 'react-to-print';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardHeader from '@mui/material/CardHeader';
+import Checkbox from '@mui/material/Checkbox';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Typography from '@mui/material/Typography';
 import styled from 'styled-components';
 
 // Internal Dependencies
@@ -31,6 +32,7 @@ import { currentDate } from '../../utils/dateHelpers';
 import { currentSchoolYearLong } from '../../utils/helpers';
 import { appNameShort } from '../../utils/app-constants';
 import CtaButton from '../shared/CtaButton';
+import EnhancedCard from '../shared/EnhancedCard';
 import FormDivider from '../shared/FormDivider';
 import FormTitle from '../shared/FormTitle';
 import Invoice from './invoice';
@@ -50,6 +52,17 @@ type ActiveMemberRadioOptions = 'active' | 'retired';
 
 // Local Variables
 const StyledRoot = styled.section(({ theme }) => ({
+  '.MuiCardContent-root': {
+    padding: 0,
+  },
+  '.MuiCardHeader-root': {
+    '&.top-card-header': {
+      backgroundColor: alpha(theme.palette.ui.lilac, 0.4),
+    },
+    '&.bottom-card-header': {
+      backgroundColor: alpha(theme.palette.tfaa.membership, 0.3),
+    },
+  },
   '.classChampionRadioLabelRoot': {
     alighItems: 'flex-start',
     display: 'flex',
@@ -103,6 +116,11 @@ const RegisterMemberPayment: React.FC<Props> = ({
     isActiveMember,
     setIsActiveMember,
   ] = useState<ActiveMemberRadioOptions>('active');
+  const [hasFallConferenceFee, setHasFallConferenceFee] = useState<boolean>(false);
+
+  const handleToogleHasFallConferenceFee = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setHasFallConferenceFee(event.target.checked);
+  }, []);
 
   const handleGetCurrentInvoiceId = useCallback((currentInvoiceId: number) => {
     console.log('handleGetCurrentInvoiceId : currentInvoiceId', currentInvoiceId);
@@ -122,7 +140,7 @@ const RegisterMemberPayment: React.FC<Props> = ({
   const handleCompleteMemberPaymentStep = useCallback((payment: PaypalPayment) => {
     const updatedMemberForm: MemberFormValues = {
       ...memberForm,
-      AmountPaid: isActiveMember === 'active' ? 50 : 30,
+      AmountPaid: isActiveMember === 'active' ? 75 : 30,
       PaypalPayerID: payment?.payerID,
       PaypalPaymentID: payment?.paymentID,
       PaymentOption: payment?.paymentID ? 'Paypal' : 'Invoiced',
@@ -223,7 +241,9 @@ const RegisterMemberPayment: React.FC<Props> = ({
   }, [authenticatedUserId, invoiceId, memberForm, onUpdateMemberForm, receiptId]);
 
   const isActive = isActiveMember === 'active';
-  const amount = isActive ? 50 : 30;
+  const membershipAmount = isActive ? 75 : 30;
+
+  const amount = hasFallConferenceFee ? membershipAmount + 75 : membershipAmount;
 
   const successfulMemberPaymentElement = (
     <div>
@@ -242,7 +262,7 @@ const RegisterMemberPayment: React.FC<Props> = ({
             component="span"
             variant="h4"
           >
-            — {isActive ? '$50.00' : '$30.00'}
+            — {isActive ? '$75.00' : '$30.00'}
           </Typography>
         </h3>
 
@@ -306,82 +326,102 @@ const RegisterMemberPayment: React.FC<Props> = ({
 
   // We show this if the user has not made a payment
   const invoiceMemberElement = (
-    <div>
-      <Box mb={6}>
-        <Box mb={3}>
-          <h3>Pay now with Paypal</h3>
-        </Box>
-
-        <FormControl
-          component="fieldset"
-          style={{ marginLeft: 32 }}
-        >
-          <h2 className="memberLevelHeading">
-            {memberForm.MemberType} Member
-          </h2>
-
-          <FormControl component="fieldset">
-            <RadioGroup
-              aria-label="Member Level"
-              name="MemberLevel*"
-              onChange={handleChangeRadioSelection}
-              value={isActiveMember}
-            >
-              <FormControlLabel
-                control={<Radio size="small" />}
-                label={(
-                  <>
-                    <Typography component="span">
-                      Active
-                    </Typography>
-
-                    <Typography
-                      color="textSecondary"
-                      component="span"
-                    >
-                      {' '} — $50
-                    </Typography>
-                  </>
-                )}
-                value="active"
-              />
-              <FormControlLabel
-                control={<Radio size="small" />}
-                label={(
-                  <>
-                    <Typography component="span">
-                      Retired
-                    </Typography>
-
-                    <Typography
-                      color="textSecondary"
-                      component="span"
-                    >
-                      {' '} — $30
-                    </Typography>
-                  </>
-                )}
-                value="retired"
-              />
-            </RadioGroup>
-          </FormControl>
-
-          <Typography
-            sx={{ marginTop: 1.5 }}
-            variant="body2"
+    <>
+      <EnhancedCard sx={{ marginBottom: 3 }}>
+        <CardHeader
+          className="top-card-header"
+          title="Pay now with Paypal"
+        />
+        <Box mb={6}>
+          <FormControl
+            component="fieldset"
+            style={{ marginLeft: 32 }}
           >
-            Click on the PayPal button below to pay with credit card.
-          </Typography>
+            <h2 className="memberLevelHeading">
+              {memberForm.MemberType} Member
+              {hasFallConferenceFee && ' + Fall Conference Registration'}
+            </h2>
 
-          <PaypalButtonWrapper
-            amount={amount}
-            onSuccessfulPayment={handleUpdateCompletedStep}
-          />
-        </FormControl>
-      </Box>
+            <FormControl component="fieldset">
+              <RadioGroup
+                aria-label="Member Level"
+                name="MemberLevel*"
+                onChange={handleChangeRadioSelection}
+                value={isActiveMember}
+              >
+                <FormControlLabel
+                  control={<Radio size="small" />}
+                  label={(
+                    <>
+                      <Typography component="span">
+                        Active
+                      </Typography>
 
-      <div>
-        <h3>Need to pay later?</h3>
+                      <Typography
+                        color="textSecondary"
+                        component="span"
+                      >
+                        {' '} — $75
+                      </Typography>
+                    </>
+                  )}
+                  value="active"
+                />
+                <FormControlLabel
+                  control={<Radio size="small" />}
+                  label={(
+                    <>
+                      <Typography component="span">
+                        Retired
+                      </Typography>
+
+                      <Typography
+                        color="textSecondary"
+                        component="span"
+                      >
+                        {' '} — $30
+                      </Typography>
+                    </>
+                  )}
+                  value="retired"
+                />
+              </RadioGroup>
+
+              <FormControlLabel
+                control={(
+                  <Checkbox
+                    checked={hasFallConferenceFee}
+                    onChange={handleToogleHasFallConferenceFee}
+                  />
+                )}
+                label="Add Fall Conference Registration (optional) — $75"
+              />
+            </FormControl>
+
+            <Typography variant="h6">
+              Total: ${Number(amount)?.toFixed(2).toLocaleString()}
+            </Typography>
+
+            <Typography
+              sx={{ marginTop: 4 }}
+              variant="body2"
+            >
+              Click on the PayPal button below to pay with credit card.
+            </Typography>
+
+            <PaypalButtonWrapper
+              amount={amount}
+              onSuccessfulPayment={handleUpdateCompletedStep}
+            />
+          </FormControl>
+        </Box>
+      </EnhancedCard>
+
+      <EnhancedCard>
+        <CardHeader
+          className="bottom-card-header"
+          title="Need to pay later?"
+        />
 
         <Box
           ml={4}
@@ -435,8 +475,8 @@ const RegisterMemberPayment: React.FC<Props> = ({
             </a>
           </Box>
         </Box>
-      </div>
-    </div>
+      </EnhancedCard>
+    </>
   );
 
   return (

--- a/src/components/register/register-member-payment.tsx
+++ b/src/components/register/register-member-payment.tsx
@@ -398,7 +398,10 @@ const RegisterMemberPayment: React.FC<Props> = ({
               />
             </FormControl>
 
-            <Typography variant="h6">
+            <Typography
+              sx={{ marginTop: 2.5 }}
+              variant="h6"
+            >
               Total: ${Number(amount)?.toFixed(2).toLocaleString()}
             </Typography>
 
@@ -432,7 +435,7 @@ const RegisterMemberPayment: React.FC<Props> = ({
             <ol>
               <li>Click the button below to print an invoice.</li>
               <li>
-                Send the invoice and payment directly to the TMAC
+                Send the invoice and payment directly to the {appNameShort}{' '}
                 Executive Secretary as detailed on the invoice.
               </li>
             </ol>
@@ -462,7 +465,7 @@ const RegisterMemberPayment: React.FC<Props> = ({
           </Box>
 
           <Box mt={3}>
-            If your organization requires the IRS W-9 Form for TMAC,
+            If your organization requires the IRS W-9 Form for {appNameShort},
             please download or print a copy below.
           </Box>
 

--- a/src/components/register/register-sponsor-payment.tsx
+++ b/src/components/register/register-sponsor-payment.tsx
@@ -210,7 +210,7 @@ const RegisterSponsorPayment: React.FC<Props> = ({
                   : (
                     <span>
                       Contact the{' '}
-                      <a href="mailto:jeffrey.turner@allenisd.org">{appNameShort} Executive Secretary</a>{' '}
+                      <a href="mailto:petwar1@yahoo.com">{appNameShort} Executive Secretary</a>{' '}
                       for more details
                     </span>
                   )}

--- a/src/components/sponsors/SponsorsTable/sponsor-table/index.tsx
+++ b/src/components/sponsors/SponsorsTable/sponsor-table/index.tsx
@@ -88,20 +88,6 @@ function getComparator<Key extends keyof Sponsor>(
     : (a, b) => -descendingComparator(a, b, orderBy);
 }
 
-function uglifyEmail(email: string) {
-  if (!email) {
-    return '';
-  }
-  const index = email.indexOf('@');
-
-  // Remove it & insert -at- back in → Array.prototype.splice()
-  const uglyEmailArray = email.split('');
-
-  uglyEmailArray.splice(index, 1, '-at-');
-
-  return uglyEmailArray.join('');
-}
-
 // Component Definition
 const SponsorTable: FC<Props> = ({
   data,
@@ -189,7 +175,7 @@ const SponsorTable: FC<Props> = ({
                       className="cell"
                       key={user.Email}
                     >
-                      {uglifyEmail(user.Email)}
+                      {user.Email}
                     </TableCell>
 
                     {isAdmin && (

--- a/src/pages/events/summer-round-table.tsx
+++ b/src/pages/events/summer-round-table.tsx
@@ -118,7 +118,6 @@ const SummerRoundTable: FC<Props> = ({ location }) => {
                       size="small"
                       sx={{
                         marginLeft: 1.5,
-                        // paddingY: 1,
                       }}
                     />
                   </Box>

--- a/src/pages/members/MemberActions.js
+++ b/src/pages/members/MemberActions.js
@@ -189,7 +189,7 @@ const MemberActions = ({
             <Button
               className="emailButton"
               color="primary"
-              href="mailto:jeffrey.turner@allenisd.org"
+              href="mailto:petwar1@yahoo.com"
               size="small"
               variant="outlined"
             >

--- a/src/pages/members/member-table/index.tsx
+++ b/src/pages/members/member-table/index.tsx
@@ -91,20 +91,6 @@ function getComparator<Key extends keyof TfaaMemberData>(
     : (a, b) => -descendingComparator(a, b, orderBy);
 }
 
-function uglifyEmail(email: string) {
-  if (!email) {
-    return '';
-  }
-  const index = email.indexOf('@');
-
-  // Remove it & insert -at- back in → Array.splice()
-  const uglyEmailArray = email.split('');
-
-  uglyEmailArray.splice(index, 1, '-at-');
-
-  return uglyEmailArray.join('');
-}
-
 // Component Definition
 const MemberTable: FC<Props> = ({
   data,
@@ -204,7 +190,7 @@ const MemberTable: FC<Props> = ({
                       className="cell"
                       key={user.Email}
                     >
-                      {uglifyEmail(user.Email)}
+                      {user.Email}
                     </TableCell>
 
                     {isAdmin && (

--- a/src/pages/sponsors/sponsor-info.tsx
+++ b/src/pages/sponsors/sponsor-info.tsx
@@ -41,7 +41,7 @@ const StyledRoot = styled.div(({ theme }) => ({
 
 // Component Definition
 const SponsorInfo: React.FC<Props> = ({ location }) => {
-  // We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
+  // We normally shut down registration and sponsorship after TMEA each year and open it up on 8/1
   const showSponsorshipInfo = isTodayAfterJuly31st;
 
   return (

--- a/src/pages/sponsors/sponsor-info.tsx
+++ b/src/pages/sponsors/sponsor-info.tsx
@@ -85,7 +85,7 @@ const SponsorInfo: React.FC<Props> = ({ location }) => {
                     </li>
 
                     <li>
-                      To pay, mail invoice with check to the {appNameShort} Treasurer.
+                      To pay, mail invoice with check to the {appNameShort} Executive Secretary.
                     </li>
                   </ol>
               </>

--- a/src/utils/app-constants.js
+++ b/src/utils/app-constants.js
@@ -4,10 +4,10 @@ export const appNameOld = 'Texas Music Administrators Conference';
 export const appNameOldShort = 'TMAC';
 
 export const mailingAddress = {
-  addressOne: '1732 Falmouth Dr.',
-  city: 'Plano',
+  addressOne: '4107 Natural Bridge Court',
+  city: 'Round Rock',
   state: 'TX',
-  zip: '75025',
+  zip: '78681',
 };
 
 export const facebookUrl = 'https://www.facebook.com/TFAA.tmac';

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -54,7 +54,7 @@ export const currentYearShort = format(new Date(), 'yy');
 // new Date(2023, 7, 1) → 8/1/2023
 export const isTodayAfterJuly31st = isAfter(
   new Date(),
-  new Date(parseInt(currentYearLong, 10), 6, 1),
+  new Date(parseInt(currentYearLong, 10), 7, 1),
 );
 
 export const currentSchoolYearShort = isTodayAfterJuly31st

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -40,10 +40,10 @@ export const currentYearLong = format(new Date(), 'yyyy');
 // Current Year - two-digit string
 export const currentYearShort = format(new Date(), 'yy');
 
-// We normally shut down registration and sponsorship after TMEA each year and open it up on 7/1
+// We normally shut down registration and sponsorship after TMEA each year and open it up on 8/1
 // Use the `isTodayAfterJune30th` helper
 
-// The "year" for TMAC starts on 7/1
+// The "year" for TMAC starts on 8/1
 // new Date(2021, 6, 1) → 7/1/2021
 // export const isTodayAfterJune30th = isAfter(
 //   new Date(),
@@ -54,7 +54,7 @@ export const currentYearShort = format(new Date(), 'yy');
 // new Date(2023, 7, 1) → 8/1/2023
 export const isTodayAfterJuly31st = isAfter(
   new Date(),
-  new Date(parseInt(currentYearLong, 10), 7, 1),
+  new Date(parseInt(currentYearLong, 10), 6, 1),
 );
 
 export const currentSchoolYearShort = isTodayAfterJuly31st

--- a/src/utils/member-constants.js
+++ b/src/utils/member-constants.js
@@ -2,13 +2,13 @@ export const ADMIN_USER_EMAIL_LIST = [
   'dinah.menger@fwisd.org',
   'james.drew@fortbendisd.com',
   'jclark@springisd.org',
-  'jeffrey.turner@allenisd.org',
+  'petwar1@yahoo.com', // Executive Secretary
   'manuel.gamez@pfisd.net',
   'm2mathew@me.com',
   'mike@drumsensei.com',
 ];
 
-export const TMAC_WEB_EXECUTIVE_SECRETARY = 'jeffrey.turner@allenisd.org';
+export const TMAC_WEB_EXECUTIVE_SECRETARY = 'petwar1@yahoo.com';
 
 export const TMAC_WEB_ADMIN_EMAIL_LIST = [
   'm2mathew@me.com',


### PR DESCRIPTION
# Solution

- Clean up registration forms
- Add checkbox for paying for Fall Conference
- Show Total in form
- Add cards around payment step areas
- Update Exec Secretary data
- Remove some rogue `TMAC`s hanging out still
- Pass along the new value `IsRegisteredForFallConference` to the firestore

# Visuals

Simplify the stepper

<img width="872" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/8b95ece6-4a14-4f70-b1e3-0f90aacfe4e6">

Payment form clean up

<img width="473" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/7217f33a-a690-4850-9d81-4daa93731eac">

