### PR TITLE
refactor: sponsor page image update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/sponsors/SponsorsBanner.tsx
+++ b/src/components/sponsors/SponsorsBanner.tsx
@@ -99,19 +99,19 @@ const SponsorsBanner: FC = () => {
 
       <List>
         <ListItem>
-          &bull; {appNameShort} offers many different sponsorship opportunities at varying levels of engagement.
+          {appNameShort} offers many different sponsorship opportunities at varying levels of engagement.
         </ListItem>
 
         <ListItem>
-          &bull; Our sponsors play a vital role in our organization&apos;s ongoing success by providing financial support and other valuable services.
+          Our sponsors play a vital role in our organization&apos;s ongoing success by providing financial support and other valuable services.
         </ListItem>
 
         <ListItem>
-          &bull; In return, your business will be recognized as an official sponsor, which benefits you and TFAA.
+          In return, your business will be recognized as an official sponsor, which benefits you and TFAA.
         </ListItem>
 
         <ListItem>
-          &bull; The Board seeks to provide relevant professional learning, while simultaneously offering our sponsors the opportunity to interact meaningfully with our members at TFAA events.
+          The Board seeks to provide relevant professional learning, while simultaneously offering our sponsors the opportunity to interact meaningfully with our members at TFAA events.
         </ListItem>
       </List>
     </StyledRoot>

--- a/src/components/sponsors/SponsorsBanner.tsx
+++ b/src/components/sponsors/SponsorsBanner.tsx
@@ -107,11 +107,11 @@ const SponsorsBanner: FC = () => {
         </ListItem>
 
         <ListItem>
-          In return, your business will be recognized as an official sponsor, which benefits you and TFAA.
+          In return, your business will be recognized as an official sponsor, which benefits you and {appNameShort}.
         </ListItem>
 
         <ListItem>
-          The Board seeks to provide relevant professional learning, while simultaneously offering our sponsors the opportunity to interact meaningfully with our members at TFAA events.
+          The Board seeks to provide relevant professional learning, while simultaneously offering our sponsors the opportunity to interact meaningfully with our members at {appNameShort} events.
         </ListItem>
       </List>
     </StyledRoot>

--- a/src/components/sponsors/SponsorsList.tsx
+++ b/src/components/sponsors/SponsorsList.tsx
@@ -1,8 +1,10 @@
 // External Dependencies
+import Box from '@mui/material/Box';
 import React from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import Collapse from '@mui/material/Collapse';
 import Divider from '@mui/material/Divider';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Typography from '@mui/material/Typography';
 import styled from 'styled-components';
 
@@ -10,7 +12,7 @@ import styled from 'styled-components';
 import { appNameShort } from '../../utils/app-constants';
 import { useGetSponsorData } from '../../utils/hooks/useGetSponsorData';
 import Motifs from '../shared/Motifs';
-import SponsorCard from './SponsorCard';
+// import SponsorCard from './SponsorCard';
 
 // Local Variables
 const StyledRoot = styled.section(({ theme }) => ({
@@ -20,6 +22,15 @@ const StyledRoot = styled.section(({ theme }) => ({
 
   '.MuiCircularProgress-root': {
     color: theme.palette.tfaa.resources,
+  },
+
+  '.eventsList > a': {
+    fontSize: 19,
+  },
+
+  '.eventsList > img': {
+    maxWidth: 800,
+    width: '100%',
   },
 
   '.resourcessTitle': {
@@ -47,6 +58,15 @@ const StyledRoot = styled.section(({ theme }) => ({
   width: '100%',
 }));
 
+const StyledOpenInNewIcon = styled(OpenInNewIcon)({
+  '&&': {
+    color: 'inherit',
+    fontSize: '0.8em',
+    marginLeft: '0.25em',
+  }
+}) as typeof OpenInNewIcon;
+
+
 // Flip this to test with fake Sponsor data in local development
 const useTestData = false;
 
@@ -54,12 +74,12 @@ const useTestData = false;
 const SponsorsList: React.FC = () => {
   const {
     isLoading,
-    sponsorData,
+    // sponsorData,
   } = useGetSponsorData({ useTestData });
 
-  const classChampionSponsors = sponsorData?.filter((sponsor) => sponsor.SponsorLevel === 'Class Champion');
-  const goldMedalSponsors = sponsorData?.filter((sponsor) => sponsor.SponsorLevel === 'Gold Medal');
-  const silverMedalSponsors = sponsorData?.filter((sponsor) => sponsor.SponsorLevel === 'Silver Medal');
+  // const classChampionSponsors = sponsorData?.filter((sponsor) => sponsor.SponsorLevel === 'Class Champion');
+  // const goldMedalSponsors = sponsorData?.filter((sponsor) => sponsor.SponsorLevel === 'Gold Medal');
+  // const silverMedalSponsors = sponsorData?.filter((sponsor) => sponsor.SponsorLevel === 'Silver Medal');
 
   return (
     <StyledRoot>
@@ -82,7 +102,7 @@ const SponsorsList: React.FC = () => {
 
         <Collapse in={!isLoading}>
           <div className="eventsList">
-            <SponsorCard
+            {/* <SponsorCard
               sponsorData={classChampionSponsors}
               sponsorLevel="Class Champion"
             />
@@ -93,7 +113,18 @@ const SponsorsList: React.FC = () => {
             <SponsorCard
               sponsorData={silverMedalSponsors}
               sponsorLevel="Silver Medal"
-            />
+            /> */}
+            <img src="https://res.cloudinary.com/tmac/image/upload/v1692272429/Sponsor_Levels_combined.png"/>
+
+            <Box marginTop={3}>
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLScixBGNVLwsLURlTHn0Y35Ix11uYOM9s4gEG00SPH3BVhPrZA/viewform?usp=sharing"
+              target="_blank"
+            >
+              Please select this link to complete the Sponsorship Registration Form and submit payments.
+              <StyledOpenInNewIcon />
+            </a>
+            </Box>
           </div>
         </Collapse>
       </div>

--- a/src/pages/sponsors/register.tsx
+++ b/src/pages/sponsors/register.tsx
@@ -1,10 +1,13 @@
 // External Dependencies
+import Box from '@mui/material/Box';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import React from 'react';
 import styled from 'styled-components';
 
 // Internal Dependencies
 import Layout from '../../components/layout';
-import SponsorRegisterContent from '../../components/register/SponsorRegisterContent';
+import DrumBanner from '../../components/shared/DrumBanner';
+// import SponsorRegisterContent from '../../components/register/SponsorRegisterContent';
 
 // Local Typings
 interface Props {
@@ -20,6 +23,14 @@ const StyledRoot = styled.div({
   width: '100vw',
 });
 
+const StyledOpenInNewIcon = styled(OpenInNewIcon)({
+  '&&': {
+    color: 'inherit',
+    fontSize: '0.8em',
+    marginLeft: '0.25em',
+  }
+}) as typeof OpenInNewIcon;
+
 // Component Definition
 const SponsorsRegister: React.FC<Props> = ({ location }) => {
   return (
@@ -28,7 +39,19 @@ const SponsorsRegister: React.FC<Props> = ({ location }) => {
       pageTitle="Membership Registration"
     >
       <StyledRoot>
-        <SponsorRegisterContent />
+        {/* <SponsorRegisterContent /> */}
+
+        <DrumBanner drumBannerTitle="Sponsors Registration" />
+
+        <Box marginY={6}>
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLScixBGNVLwsLURlTHn0Y35Ix11uYOM9s4gEG00SPH3BVhPrZA/viewform?usp=sharing"
+            target="_blank"
+          >
+            Please select this link to complete the Sponsorship Registration Form and submit payments.
+            <StyledOpenInNewIcon />
+          </a>
+          </Box>
       </StyledRoot>
     </Layout>
   );


### PR DESCRIPTION
- Remove the bullet points from the sponsor banner.
- Add sponsor images as provided by the TFAA Officers. This defines the tiers of sponsorship.
- Add link to a Google Form for the sponsors to fill out. 
- On the registration page for sponsors, replace content with a link to the Google Form

## Sponsors page

![localhost_8000_sponsors_register](https://github.com/m2mathew/tmac-website/assets/11624407/4f5eb242-9209-4fdc-872a-af4ec56af380)

## Sponsor registration page

![localhost_8000_sponsors_register (1)](https://github.com/m2mathew/tmac-website/assets/11624407/3d394bc9-7e55-46b3-81e0-bfc49ee4c3ad)

