### PR TITLE
Refactor/membership landing remove credit card wording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/members/NonMemberContent/MemberInfoList/MembersInfoListJoin.tsx
+++ b/src/components/members/NonMemberContent/MemberInfoList/MembersInfoListJoin.tsx
@@ -85,7 +85,7 @@ const MembersInfoListJoin: React.FC = () => {
           </li>
 
           <li>
-            Pay dues online using a credit card or PayPal (or mail invoice with check via mail).
+            Pay dues online using PayPal (or mail invoice with check via mail).
           </li>
         </ol>
 


### PR DESCRIPTION
- Remove the "credit card" wording on the members page (not signed in) per Peter Warshaw's request