### PR TITLE
fix(members): always show the Register for Fall Conference elements t…

### DIFF
--- a/src/components/members/MemberContent/MemberInfo/MemberRegistrationTasks.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberRegistrationTasks.tsx
@@ -132,7 +132,7 @@ const MemberRegistrationTasks: React.FC<Props> = ({
   if (needsToPayForFallConference) {
     fallConferenceSecondaryText = 'You are registered for the Fall Conference, but have not paid yet.';
   } else if (hasPaidForFallConference) {
-    fallConferenceSecondaryText = 'You are registered for the Fall Conference.';
+    fallConferenceSecondaryText = 'You are registered for the Fall Conference and paid in full.';
   }
 
   const successIconElement = useMemo(() => (
@@ -231,7 +231,7 @@ const MemberRegistrationTasks: React.FC<Props> = ({
             />
           </ListItem>
 
-          {isRegisteredForCurrentYear && needsToPayForFallConference && (
+          {isRegisteredForCurrentYear && !hasPaidForFallConference && (
             <ListItem className="paymentActionContainer">
               <ListItemSecondaryAction>
                 <CtaButton


### PR DESCRIPTION
All members will see the Fall Conference registration list item in the `MemberStatus` component now. This matches the logic in the `MemberRegistrationTasks` but with slightly different layout.

The key difference that regular ol' members might not realize is that "Registered" for the Fall Conference means "I intend to show up". It does not mean you have paid.

This update should clear up the issues we have been seeing regarding the members who didn't know they were able to pay again with the same logged-in user. Some people had reportedly created a second user login and registered a second time to be able to pay the Fall Conference fee.

When | Image
--- | ---
Before | <img width="833" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/3cfd3e7d-a84c-4041-a65f-4bcc9d2acea0">
After | <img width="833" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/7fa88c25-4759-4f7a-bddf-6772fbf7c6ec">
