### PR TITLE
refactor(members): simplify fall conference status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/members/MemberContent/MemberInfo/MemberRegistrationTasks.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberRegistrationTasks.tsx
@@ -5,29 +5,22 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import ListItemText from '@mui/material/ListItemText';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef } from 'react';
 import ReactToPrint from 'react-to-print';
 import Typography from '@mui/material/Typography';
 import styled, { useTheme } from 'styled-components';
 
 // Internal Dependencies
-import { DialogPayment } from './DialogPayment';
-import { TfaaAuthUser } from '../../../layout';
 import { TfaaMemberData } from '../../../../utils/hooks/useGetAllMembers';
 import { appNameShort } from '../../../../utils/app-constants';
 import { currentSchoolYearLong } from '../../../../utils/helpers';
 import CtaButton from '../../../shared/CtaButton';
 import Invoice from '../../../register/invoice';
 import MemberInfoCard from '../../../shared/MemberInfoCard';
-import usePrevious from '../../../../utils/hooks/usePrevious';
-import RegisterForFallConferenceListItem from './RegisterForFallConferenceListItem';;
 
 // Local Typings
 interface Props {
-  currentAuthUser: TfaaAuthUser | null;
   currentMemberData: TfaaMemberData | null;
-  onSetRefetchCurrentMemberData: ((shouldRefetchCurrentMemberData: boolean) => void) | null;
-  onUpdateShouldRefetchUserList: ((shouldRefetchUserList: boolean) => void) | null;
 }
 
 // Local Variables
@@ -87,47 +80,14 @@ const StyledMemberInfoCard = styled(MemberInfoCard)(({ theme }) => ({
 
 // Component Definition
 const MemberRegistrationTasks: React.FC<Props> = ({
-  currentAuthUser,
   currentMemberData,
-  onSetRefetchCurrentMemberData,
-  onUpdateShouldRefetchUserList,
 }) => {
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-
-  const previousIsDialogOpen = usePrevious(isDialogOpen);
-
-  // Local state setter functions
-  const handleOpenDialogPayment = useCallback(() => {
-    setIsDialogOpen(true);
-  }, []);
-
-  const handleCloseDialogPayment = useCallback(() => {
-    setIsDialogOpen(false);
-  }, []);
-
-  // We refetch data after the member payment dialog closes
-  useEffect(() => {
-    if (previousIsDialogOpen && !isDialogOpen) {
-      onUpdateShouldRefetchUserList?.(true);
-      onSetRefetchCurrentMemberData?.(true);
-    }
-  }, [isDialogOpen, previousIsDialogOpen, onUpdateShouldRefetchUserList]);
-
-  const userIdForFirestore = `${currentAuthUser?.email}-${currentAuthUser?.uid}`;
-
   const isRegisteredForCurrentYear = Boolean(currentMemberData);
-  const isRegisteredForFallConference  = currentMemberData?.IsRegisteredForFallConference;
 
   const theme = useTheme();
   const printReceiptRef = useRef();
 
   const needsToPay = !currentMemberData?.AmountPaid && !currentMemberData?.AmountPaid_2;
-  const hasPaidForMembership = Boolean(currentMemberData
-    && currentMemberData?.AmountPaid > 0 && currentMemberData?.AmountPaid < 100);
-  const needsToPayForFallConference = isRegisteredForFallConference
-    && (currentMemberData?.AmountPaid + currentMemberData?.AmountPaid_2) < 100;
-    const hasPaidForFallConference = isRegisteredForFallConference
-    && (currentMemberData?.AmountPaid + currentMemberData?.AmountPaid_2) >= 100;
 
   const canPrintReceipt = currentMemberData?.PaymentOption.toLowerCase() === 'paypal'
     || currentMemberData?.PaypalPaymentID;
@@ -211,15 +171,6 @@ const MemberRegistrationTasks: React.FC<Props> = ({
             />
           </ListItem>
 
-          <RegisterForFallConferenceListItem
-            hasPaidForFallConference={hasPaidForFallConference}
-            isRegisteredForCurrentYear={isRegisteredForCurrentYear}
-            needsToPayForFallConference={needsToPayForFallConference}
-            onOpenDialogPayment={handleOpenDialogPayment}
-            successIconElement={successIconElement}
-            warningIconElement={warningIconElement}
-          />
-
           {isRegisteredForCurrentYear && (
             <>
               <ListItem className="paymentListItem">
@@ -291,16 +242,6 @@ const MemberRegistrationTasks: React.FC<Props> = ({
           </div>
         )}
       </StyledMemberInfoCard>
-
-      {isDialogOpen && (
-        <DialogPayment
-          currentMemberData={currentMemberData}
-          hasPaidForMembership={hasPaidForMembership}
-          isOpen={isDialogOpen}
-          onClose={handleCloseDialogPayment}
-          userIdForFirestore={userIdForFirestore}
-        />
-      )}
     </>
   );
 };

--- a/src/components/members/MemberContent/MemberInfo/MemberStatus.tsx
+++ b/src/components/members/MemberContent/MemberInfo/MemberStatus.tsx
@@ -1,17 +1,15 @@
 // External Dependencies
 import { lighten } from '@mui/material';
 import Box from '@mui/material/Box';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
-import ErrorIcon from '@mui/icons-material/Error';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import styled, { useTheme } from 'styled-components';
+import React, { useCallback, useEffect, useState } from 'react';
+import styled from 'styled-components';
 
 // Internal Dependencies
 import { DialogPayment } from './DialogPayment';
@@ -27,7 +25,6 @@ import EnhancedAlert from '../../../shared/EnhancedAlert';
 import MemberInfoCard from '../../../shared/MemberInfoCard';
 import PrintInvoiceUI from '../../../../pages/members/PrintInvoiceUI';
 import usePrevious from '../../../../utils/hooks/usePrevious';
-import RegisterForFallConferenceListItem from './RegisterForFallConferenceListItem';
 
 // Local Typings
 interface Props {
@@ -47,6 +44,18 @@ const StyledMemberInfoCard = styled(MemberInfoCard)(({ theme }) => ({
   },
   '.contentText': {
     marginBottom: theme.spacing(2),
+  },
+  '.fallConferenceTitle': {
+    [theme.breakpoints.down('mobile')]: {
+      fontSize: 18,
+    },
+    fontSize: 26,
+    fontWeight: 700,
+    width: '100%',
+  },
+  '.fallConferenceSecondaryText': {
+    marginLeft: theme.spacing(1),
+    paddingTop: theme.spacing(0.5),
   },
   '.innerContainer': {
     paddingBottom: theme.spacing(2),
@@ -123,8 +132,6 @@ const MemberStatus: React.FC<Props> = ({
   onSetRefetchCurrentMemberData,
   onUpdateShouldRefetchUserList,
 }) => {
-  const theme = useTheme();
-
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const previousIsDialogOpen = usePrevious(isDialogOpen);
@@ -158,7 +165,9 @@ const MemberStatus: React.FC<Props> = ({
   const needsToPay = !currentMemberData?.AmountPaid && !currentMemberData?.AmountPaid_2;
 
   const hasPaidForMembershipOnly = Boolean(currentMemberData
-    && currentMemberData?.AmountPaid > 0 && currentMemberData?.AmountPaid < 100)
+    && currentMemberData?.AmountPaid > 0 && currentMemberData?.AmountPaid < 100);
+
+  const isRegisteredForFallConference = currentMemberData?.IsRegisteredForFallConference;
 
   const needsToPayForFallConference = currentMemberData?.IsRegisteredForFallConference
     && (currentMemberData?.AmountPaid + currentMemberData?.AmountPaid_2) < 100;
@@ -196,20 +205,6 @@ const MemberStatus: React.FC<Props> = ({
 
     return amountOwed;
   }, [currentMemberData, isRegisteredForCurrentYear, needsToPay, needsToPayForFallConference]);
-
-  const successIconElement = useMemo(() => (
-    <CheckCircleIcon
-      className="listItemIcon"
-      htmlColor={theme.palette.tfaa.resources}
-    />
-  ), []);
-
-  const warningIconElement = useMemo(() => (
-    <ErrorIcon
-      className="listItemIcon"
-      htmlColor={theme.palette.warning.light}
-    />
-    ), []);
 
   return (
     <>
@@ -320,33 +315,61 @@ const MemberStatus: React.FC<Props> = ({
           )}
         </Typography>
 
-        {hasPaidForFallConference && (
-          <>
-            <Divider className="memberStatusDivider" />
+        <Divider className="memberStatusDivider" />
 
-            <Typography>
-              Registered for Fall Conference
-              {successIconElement}
-            </Typography>
-          </>
-        )}
+        <Typography
+          className="fallConferenceTitle"
+          component="h3"
+        >
+          Fall Conference
+        </Typography>
 
-        {isRegisteredForCurrentYear && !hasPaidForFallConference && (
-          <>
-            <Divider className="memberStatusDivider" />
+        <List>
+          <ListItem className="listItem">
+            <ListItemText
+              classes={{
+                primary: 'listItemText',
+                secondary: 'fallConferenceSecondaryText',
+              }}
+              primary={(
+                <>
+                  {!isRegisteredForFallConference && 'Not registered'}
 
-            <List sx={{ marginBottom: 2 }}>
-              <RegisterForFallConferenceListItem
-                hasPaidForFallConference={hasPaidForFallConference}
-                isRegisteredForCurrentYear={isRegisteredForCurrentYear}
-                needsToPayForFallConference={needsToPayForFallConference}
-                onOpenDialogPayment={handleOpenDialogPayment}
-                successIconElement={successIconElement}
-                warningIconElement={warningIconElement}
-              />
-            </List>
-          </>
-        )}
+                  {isRegisteredForFallConference && 'Registered'}
+                </>
+              )}
+              secondary={(
+                <>
+                  {isRegisteredForFallConference && needsToPayForFallConference && (
+                    <>
+                      Outstanding balance: $75.00
+                    </>
+                  )}
+
+                  {isRegisteredForFallConference && hasPaidForFallConference && (
+                    <>
+                      Paid in full
+                    </>
+                  )}
+                </>
+              )}
+            />
+          </ListItem>
+
+          {isRegisteredForCurrentYear && !hasPaidForFallConference && (
+            <ListItem className="paymentActionContainer">
+              <ListItemSecondaryAction>
+                <CtaButton
+                  colorVariant="resources"
+                  fontWeight={600}
+                  onClick={handleOpenDialogPayment}
+                >
+                  {needsToPayForFallConference ? 'Pay' : 'Register'} for Fall Conference
+                </CtaButton>
+              </ListItemSecondaryAction>
+            </ListItem>
+          )}
+        </List>
 
         {isRegisteredForCurrentYear && isInvoiced && (
           <>

--- a/src/components/members/MemberContent/MemberInfo/RegisterForFallConferenceListItem.tsx
+++ b/src/components/members/MemberContent/MemberInfo/RegisterForFallConferenceListItem.tsx
@@ -17,6 +17,10 @@ interface Props {
   warningIconElement: JSX.Element;
 }
 
+/*
+ * Deprecated
+ */
+
 // Component Definition
 const RegisterForFallConferenceListItem = ({
   hasPaidForFallConference,

--- a/src/components/members/MemberContent/MemberInfo/index.tsx
+++ b/src/components/members/MemberContent/MemberInfo/index.tsx
@@ -90,10 +90,7 @@ const MemberInfo: React.FC<Props> = ({
       )}
 
       <MemberRegistrationTasks
-        currentAuthUser={currentAuthUser}
         currentMemberData={currentMemberData}
-        onSetRefetchCurrentMemberData={onSetRefetchCurrentMemberData}
-        onUpdateShouldRefetchUserList={onUpdateShouldRefetchUserList}
       />
 
       <MemberActions


### PR DESCRIPTION
# The Issue

TFAA President Jim Drew had some solid advice:

```
The Fall Conference status seems a bit confusing.

First of all, please remove “(optional)” as it’s not necessary.

Then, just provide a “Fall Conference status” like the “Membership status”:

Not registered

Registered
  Outstanding balance: $75.00

Registered
  Paid in full
```

# The Solution

- Add UI for all of the variations for the Fall Conference
- Remove the Fall Conf UI from the `MemberRegistrationTasks` area


# Visuals

Scenario | Image
--- | ---
Not registered as member, No Fall Conference | <img width="685" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/a0d8e2ae-76bf-43c1-a769-76db2215e619">
Registered as member/paid, No Fall Conference | <img width="685" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/ddbd80c1-0354-4b0f-89e4-b96498e7400f">
Registered as member/paid, Registered for Fall Conference, not paid | <img width="685" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/b61bb2b0-bc97-4574-9aac-e609d65c7f0f">
Registered as member/paid, Registered for Fall Conference, paid in full for all | <img width="685" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/0fca71a1-5993-48bb-b02d-aba0dd23fc7d">
