### PR TITLE
Fix/remove redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,0 @@
-/* https://texasfineartsadmin.com/ 301!


### PR DESCRIPTION
The TFAA site is redirecting to the old TMAC site, which redirects back. Infinite loop scenario.