### PR TITLE
Fix/improve new sponsor form alert ux

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmac-website",
   "description": "Website for the Texas Music Administrators Conference",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/m2mathew/tmac-website"

--- a/src/components/sponsors/SponsorsNew/NewSponsorFormikForm.tsx
+++ b/src/components/sponsors/SponsorsNew/NewSponsorFormikForm.tsx
@@ -14,7 +14,6 @@ import {
 } from '.';
 import { SPONSOR_LEVEL_OPTIONS } from './constants';
 import CloudinaryUploadWidget from '../../shared/CloudinaryUploadWidget';
-import CtaButton from '../../shared/CtaButton';
 import CustomSelect from '../../shared/CustomSelect';
 import CustomTextField from '../../shared/CustomTextField';
 import EnhancedAlert from '../../shared/EnhancedAlert';
@@ -73,6 +72,7 @@ const NewSponsorFormikForm: React.FC<Props> = ({
   }
 
   const shouldPreventSubmit = hasTouchedForm && (hasErrors || !imageUrl);
+  const isReadyToSubmit = hasTouchedForm && !shouldPreventSubmit;
 
   return (
     <Form onSubmit={onFormikSubmit}>
@@ -169,26 +169,38 @@ const NewSponsorFormikForm: React.FC<Props> = ({
         value={formikValues.honeypot}
       />
 
-      <Box
-        mb={2.5}
-        mt={1}
-        width="100%"
-      >
-        <EnhancedAlert severity={shouldPreventSubmit ? 'error' : 'info'}>
-          Please enter a value in each required field and upload a logo image.
-        </EnhancedAlert>
-      </Box>
+      <Collapse in={!isReadyToSubmit}>
+        <Box
+          mb={2.5}
+          mt={1}
+          width="100%"
+        >
+          <EnhancedAlert severity={shouldPreventSubmit ? 'error' : 'info'}>
+            Please enter a value in each required field and upload a logo image.
+          </EnhancedAlert>
+        </Box>
+      </Collapse>
 
-      <CtaButton
+      <Collapse in={isReadyToSubmit}>
+        <Box
+          mb={2.5}
+          mt={1}
+          width="100%"
+        >
+          <EnhancedAlert severity="success">
+            Data looks good! Press the button below to add this sponsor.
+          </EnhancedAlert>
+        </Box>
+      </Collapse>
+
+      <Button
         disabled={shouldPreventSubmit}
-        fontWeight={600}
-        rightArrow
         size="large"
         type="submit"
-        width={240}
+        variant="contained"
       >
         Add Sponsor
-      </CtaButton>
+      </Button>
     </Form>
   );
 };


### PR DESCRIPTION
The Executive Secretary was thrown off by the alert messaging. We can improve the UX by adding a better success alert and making the button more obvious (trending away from the pill-shaped buttons in the site).

### Before

<img width="981" alt="image" src="https://github.com/m2mathew/tmac-website/assets/11624407/415ab141-10ac-4e88-a85a-e07fde3cd41c">

### After

<img width="981" alt="Screenshot 2023-09-18 at 3 11 53 PM" src="https://github.com/m2mathew/tmac-website/assets/11624407/e7677fda-024c-498a-ab28-bba9bb9decdd">
